### PR TITLE
Close connections even on failure

### DIFF
--- a/R/importKCL.R
+++ b/R/importKCL.R
@@ -544,7 +544,6 @@ importKCL <- function(site = "my1", year = 2009, pollutant = "all", met = FALSE,
       fileName <- paste("http://www.londonair.org.uk/r_data/", x, ".RData", sep = "")
       con <- url(fileName)
       load(con)
-      close(con)
 
       ## need to check the date starts at start of year...
       start <- ISOdatetime(
@@ -563,6 +562,9 @@ importKCL <- function(site = "my1", year = 2009, pollutant = "all", met = FALSE,
     },
     error = function(ex) {
       cat(x, "does not exist - ignoring that one.\n")
+    },
+    finally = {
+      close(con)
     }
     )
   }

--- a/R/importSAQN.R
+++ b/R/importSAQN.R
@@ -110,11 +110,13 @@ importSAQN <- function(site = "gla4", year = 2009, pollutant = "all") {
       fileName <- paste("http://www.scottishairquality.co.uk/openair/R_data/", x, ".RData", sep = "")
       con <- url(fileName)
       load(con, envir = .GlobalEnv)
-      close(con)
       x
     },
     error = function(ex) {
       cat(x, "does not exist - ignoring that one.\n")
+    },
+    finally = {
+        close(con)
     }
     )
   }

--- a/R/importTraj.R
+++ b/R/importTraj.R
@@ -151,7 +151,6 @@ importTraj <- function(site = "london", year = 2009, local = NA) {
 
         con <- url(fileName)
         load(con)
-        close(con)
       } else { ## load from local file system
 
         con <- paste(local, x, ".RData", sep = "")
@@ -163,6 +162,9 @@ importTraj <- function(site = "london", year = 2009, local = NA) {
     },
     error = function(ex) {
       cat(x, "does not exist - ignoring that one.\n")
+    },
+    finally = {
+        close(con)
     }
     )
   }


### PR DESCRIPTION
Currently connections aren't closed if the requested data file doesn't exist. This is a problem when we want to get data from all sites, using something like this:

```r
sites <- importMeta(source="kcl")$code
data <- importKCL(site=sites, year=2001:2004)
```

This eventually leads to the ``all connections are in use`` error (as reported in #167). This PR fixes the issue by always closing the connection. The importKCL function has been tested with this change and it resolves the issue.