### PR TITLE
Fix trajCluster where plot = FALSE

### DIFF
--- a/R/trajCluster.R
+++ b/R/trajCluster.R
@@ -314,10 +314,14 @@ trajCluster <- function(traj, method = "Euclid", n.cluster = 5,
 
     ## plot
     plt <- do.call(scatterPlot, plot.args)
+    
+    ## create output with plot
+    output <- list(plot = plt, data = traj, results = resRtn, call = match.call())
+    class(output) <- "openair"
+    invisible(output)
+  } else {
+    ## create output without plot
+    return(traj)
   }
 
-
-  output <- list(plot = plt, data = traj, results = resRtn, call = match.call())
-  class(output) <- "openair"
-  invisible(output)
 }


### PR DESCRIPTION
As written, `trajCluster(traj, plot = FALSE)` errors as it tries to assign the non-existent `plt` to the `output` list. 

This is a fix such that, when `plot = FALSE`, only the clustered data frame is returned.

It could alternatively still return a list of `data` and `call` to be more consistent with its `plot = TRUE` behaviour, but just returning the data frame feels more practical (e.g., it'd be easier to assign it and use it without indexing a list, and can easily be used in a `{magrittr}` pipeline).