### PR TITLE
:sparkles: add month.last argument to timeVariation function to allow…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: openair
 Type: Package
 Title: Tools for the Analysis of Air Pollution Data
-Version: 2.10-0
-Date: 2022-06-21
+Version: 2.10-01
+Date: 2022-08-10
 Authors@R: c(person("David", "Carslaw", role = c("aut", "cre"), email =
     "david.carslaw@york.ac.uk"), person("Karl", "Ropkins", role =
     "aut", email = "K.Ropkins@its.leeds.ac.uk"))

--- a/R/timeVariation.R
+++ b/R/timeVariation.R
@@ -161,6 +161,9 @@
 ##'   NO2.
 ##' @param alpha The alpha transparency used for plotting confidence intervals.
 ##'   0 is fully transparent and 1 is opaque. The default is 0.4
+##' @param month.last Should the order of the plots be changed so the plot 
+##'   showing monthly means be the last plot for a logical hierarchy of 
+##'   averaging periods?
 ##' @param ... Other graphical parameters passed onto \code{lattice:xyplot} and
 ##'   \code{cutData}. For example, in the case of \code{cutData} the option
 ##'   \code{hemisphere = "southern"}.
@@ -273,7 +276,8 @@ timeVariation <- function(mydata, pollutant = "nox", local.tz = NULL,
                           type = "default", group = NULL, difference = FALSE,
                           statistic = "mean", conf.int = 0.95, B = 100, ci = TRUE, cols = "hue",
                           ref.y = NULL, key = NULL, key.columns = 1, start.day = 1,
-                          auto.text = TRUE, alpha = 0.4, ...) {
+                          auto.text = TRUE, alpha = 0.4, month.last = FALSE, 
+                          ...) {
 
   ## get rid of R check annoyances
   variable <- NULL
@@ -990,9 +994,21 @@ timeVariation <- function(mydata, pollutant = "nox", local.tz = NULL,
         )
       ), position = c(0, 0.5, 1, y.upp), more = TRUE)
     }
-    print(hour, position = c(0, y.dwn, 0.33, 0.53), more = TRUE)
-    print(month, position = c(0.33, y.dwn, 0.66, 0.53), more = TRUE)
-    print(day, position = c(0.66, y.dwn, 1, 0.53))
+    
+    # Build the plot panels in different orders
+    if (!month.last) {
+      # The original plot orders
+      print(hour, position = c(0, y.dwn, 0.33, 0.53), more = TRUE)
+      print(month, position = c(0.33, y.dwn, 0.66, 0.53), more = TRUE)
+      print(day, position = c(0.66, y.dwn, 1, 0.53))
+    } else {
+      # Move around the plot order so they follow a logical hierarchy of averaging
+      # periods hour-day-month
+      print(hour, position = c(0, y.dwn, 0.33, 0.53), more = TRUE)
+      print(day, position = c(0.33, y.dwn, 0.66, 0.53), more = TRUE)
+      print(month, position = c(0.66, y.dwn, 1, 0.53))
+    }
+    
     ## use grid to add an overall title
     grid.text(overall.main, 0.5, y.upp, gp = gpar(fontsize = 14))
     grid.text(overall.sub, 0.5, y.dwn, gp = gpar(fontsize = 12))

--- a/man/timeVariation.Rd
+++ b/man/timeVariation.Rd
@@ -25,6 +25,7 @@ timeVariation(
   start.day = 1,
   auto.text = TRUE,
   alpha = 0.4,
+  month.last = FALSE,
   ...
 )
 }
@@ -153,6 +154,10 @@ NO2.}
 
 \item{alpha}{The alpha transparency used for plotting confidence intervals.
 0 is fully transparent and 1 is opaque. The default is 0.4}
+
+\item{month.last}{Should the order of the plots be changed so the plot 
+showing monthly means be the last plot for a logical hierarchy of 
+averaging periods?}
 
 \item{...}{Other graphical parameters passed onto \code{lattice:xyplot} and
 \code{cutData}. For example, in the case of \code{cutData} the option


### PR DESCRIPTION
Hello David,
Here is a minor edit to the `timeVariation` function to allow the user to display the sub-plots in a hour-weekday-month order using a new `month.last` argument. This has been done after some feedback I received a the air quality conference last month.
Stuart.
