### PR TITLE
Add "plot" option to (almost) all openair plotting functions

### DIFF
--- a/R/TheilSen.R
+++ b/R/TheilSen.R
@@ -157,7 +157,7 @@
 ##'   have more control. For format types see \code{strptime}. For
 ##'   example, to format the date like \dQuote{Jan-2012} set
 ##'   \code{date.format = "\%b-\%Y"}.
-##' @param plot Should a plot be produced. \code{FALSE} can be useful when
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
 ##'   analysing data to extract trend components and plotting them in other
 ##'   ways.
 ##' @param silent When \code{FALSE} the function will give updates on

--- a/R/calendarPlot.R
+++ b/R/calendarPlot.R
@@ -114,6 +114,9 @@
 ##' @param auto.text Either \code{TRUE} (default) or \code{FALSE}. If
 ##'   \code{TRUE} titles and axis labels will automatically try and format
 ##'   pollutant names and units properly e.g.  by subscripting the `2' in NO2.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract calendar plot components and plotting them in
+##'   other ways.
 ##' @param ... Other graphical parameters are passed onto the \code{lattice}
 ##'   function \code{lattice:levelplot}, with common axis and title labelling
 ##'   options (such as \code{xlab}, \code{ylab}, \code{main}) being passed to
@@ -172,7 +175,7 @@ calendarPlot <- function(mydata, pollutant = "nox", year = 2003, month = 1:12,
                          breaks = NA, w.shift = 0, remove.empty = TRUE,
                          main = NULL,
                          key.header = "", key.footer = "",
-                         key.position = "right", key = TRUE, auto.text = TRUE,
+                         key.position = "right", key = TRUE, auto.text = TRUE, plot = TRUE,
                          ...) {
   conc.mat <- NULL ## keep R check quiet
 
@@ -557,8 +560,10 @@ calendarPlot <- function(mydata, pollutant = "nox", year = 2003, month = 1:12,
   lv.args <- listUpdate(lv.args, extra.args)
 
   ## plot
-  print(do.call(levelplot, lv.args))
-
+  if (plot) {
+    print(do.call(levelplot, lv.args))
+  }
+  
   ## reset theme
   lattice.options(default.theme = def.theme)
 

--- a/R/corPlot.R
+++ b/R/corPlot.R
@@ -69,6 +69,9 @@
 ##' @param auto.text Either \code{TRUE} (default) or \code{FALSE}. If
 ##'   \code{TRUE} titles and axis labels will automatically try and format
 ##'   pollutant names and units properly e.g.  by subscripting the `2' in NO2.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract corPlot components and plotting them in other
+##'   ways.
 ##' @param ... Other graphical parameters passed onto \code{lattice:levelplot},
 ##'   with common axis and title labelling options (such as \code{xlab},
 ##'   \code{ylab}, \code{main}) being passed via \code{quickText} to handle
@@ -123,8 +126,10 @@ corPlot <- function(mydata, pollutants = NULL, type = "default",
                     dendrogram = FALSE, 
                     lower = FALSE,
                     cols = "default",
-                    r.thresh = 0.8, text.col =
-                    c("black", "black"), auto.text = TRUE, ...) {
+                    r.thresh = 0.8, text.col = c("black", "black"), 
+                    auto.text = TRUE, 
+                    plot = TRUE,
+                    ...) {
   if (length(type) > 1) stop("Only one 'type' allowed in this function.")
 
   ## make sure date is present for types requiring it
@@ -382,7 +387,7 @@ corPlot <- function(mydata, pollutants = NULL, type = "default",
   # output
   #################
 
-  plot(plt)
+  if (plot) plot(plt)
 
   ## openair object
 

--- a/R/linearRelation.R
+++ b/R/linearRelation.R
@@ -83,6 +83,9 @@
 ##'     automatically. The user can therefore increase or decrease the
 ##'     number of intervals by adjusting the value of
 ##'     \code{date.breaks} up or down.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other
+##'   ways.
 ##' @param ... Other graphical parameters. A useful one to remove the
 ##'     strip with the date range on at the top of the plot is to set
 ##'     \code{strip = FALSE}.
@@ -123,11 +126,19 @@
 ##' \dontrun{linearRelation(mydata, x = "pm10", y = "pm25", rsq.thresh = 0.8)}
 ##'
 ##'
-linearRelation <- function(mydata, x = "nox", y = "no2",
-                           period = "month", condition = FALSE,
-                           n = 20, rsq.thresh = 0,
+linearRelation <- function(mydata,
+                           x = "nox",
+                           y = "no2",
+                           period = "month",
+                           condition = FALSE,
+                           n = 20,
+                           rsq.thresh = 0,
                            ylab = paste0("slope from ", y, " = m.", x, " + c"),
-                           auto.text = TRUE, cols = "grey30", date.breaks= 5, ...) {
+                           auto.text = TRUE,
+                           cols = "grey30",
+                           date.breaks = 5,
+                           plot = TRUE,
+                           ...) {
 
   ## get rid of R check annoyances
   nox <- ox <- cond <- rsquare <- N <- r.thresh <- NULL
@@ -471,7 +482,13 @@ linearRelation <- function(mydata, x = "nox", y = "no2",
     plt <- do.call(xyplot, xyplot.args)
   }
 
-  if (condition & period == "day.hour") print(useOuterStrips(plt)) else print(plt)
+  if (plot) {
+    if (condition &
+        period == "day.hour")
+      print(useOuterStrips(plt))
+    else
+      print(plt)
+  }
 
   #################
   # output

--- a/R/percentileRose.R
+++ b/R/percentileRose.R
@@ -113,6 +113,9 @@
 ##'   \code{"right"}, \code{"bottom"} and \code{"left"}.
 ##' @param key Fine control of the scale key via \code{drawOpenKey}.
 ##'   See \code{drawOpenKey} for further details.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other
+##'   ways.
 ##' @param ... Other graphical parameters are passed onto
 ##'   \code{cutData} and \code{lattice:xyplot}. For example,
 ##'   \code{percentileRose} passes the option \code{hemisphere =
@@ -172,7 +175,7 @@ percentileRose <- function(mydata, pollutant = "nox", wd = "wd", type = "default
                            fill = TRUE, intervals = NULL, angle.scale = 45,
                            auto.text = TRUE, key.header = NULL,
                            key.footer = "percentile", key.position = "bottom",
-                           key = TRUE, ...) {
+                           key = TRUE, plot = TRUE, ...) {
 
   ## get rid of R check annoyances
   sub <- NULL
@@ -647,7 +650,13 @@ percentileRose <- function(mydata, pollutant = "nox", wd = "wd", type = "default
 
   ## output ####################################################################################
 
-  if (length(type) == 1) plot(plt) else plot(useOuterStrips(plt, strip = strip, strip.left = strip.left))
+  if (plot) {
+    if (length(type) == 1) {
+      plot(plt)
+    } else {
+      plot(useOuterStrips(plt, strip = strip, strip.left = strip.left))
+    }
+  }
 
   output <- list(plot = plt, data = newdata, call = match.call())
   class(output) <- "openair"

--- a/R/polarAnnulus.R
+++ b/R/polarAnnulus.R
@@ -177,6 +177,9 @@
 ##'   \code{TRUE} titles and axis labels will automatically try and format
 ##'   pollutant names and units properly e.g.  by subscripting the \sQuote{2}
 ##'   in NO2.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other
+##'   ways.
 ##' @param ... Other graphical parameters passed onto \code{lattice:levelplot}
 ##'   and \code{cutData}. For example, \code{polarAnnulus} passes the option
 ##'   \code{hemisphere = "southern"} on to \code{cutData} to provide southern
@@ -229,7 +232,7 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
                          k = c(20, 10), normalise = FALSE,
                          key.header = "", key.footer = pollutant,
                          key.position = "right", key = TRUE,
-                         auto.text = TRUE, ...) {
+                         auto.text = TRUE, plot = TRUE, ...) {
 
   ## get rid of R check annoyances
   wd <- u <- v <- z <- all.dates <- NULL
@@ -761,7 +764,13 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
   #################
   # output
   #################
-  if (length(type) == 1) plot(plt) else plot(useOuterStrips(plt, strip = strip, strip.left = strip.left))
+  if (plot) {
+    if (length(type) == 1) {
+      plot(plt) 
+    } else {
+      plot(useOuterStrips(plt, strip = strip, strip.left = strip.left))
+    }
+  }
   newdata <- results.grid
   output <- list(plot = plt, data = newdata, call = match.call())
   class(output) <- "openair"

--- a/R/polarCluster.R
+++ b/R/polarCluster.R
@@ -93,6 +93,9 @@
 ##' @param auto.text Either \code{TRUE} (default) or \code{FALSE}. If
 ##'   \code{TRUE} titles and axis labels will automatically try and format
 ##'   pollutant names and units properly e.g.  by subscripting the `2' in NO2.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other
+##'   ways.
 ##' @param ... Other graphical parameters passed onto \code{polarPlot},
 ##'   \code{lattice:levelplot} and \code{cutData}. Common axis and title
 ##'   labelling options (such as \code{xlab}, \code{ylab}, \code{main}) are
@@ -157,7 +160,7 @@
 polarCluster <- function(mydata, pollutant = "nox", x = "ws", wd = "wd", n.clusters = 6,
                          after = NA,
                          cols = "Paired", angle.scale = 315, units = x, 
-                         auto.text = TRUE, ...) {
+                         auto.text = TRUE, plot = TRUE, ...) {
 
   ## avoid R check annoyances
   u <- v <- z <- strip <- strip.left <- NULL
@@ -236,6 +239,7 @@ polarCluster <- function(mydata, pollutant = "nox", x = "ws", wd = "wd", n.clust
     
     results.grid <- polarDiff(before = mydata,
                               after = after,
+                              plot = FALSE,
                               pollutant = pollutant,
                               cluster = TRUE, ...)$data
     
@@ -243,7 +247,8 @@ polarCluster <- function(mydata, pollutant = "nox", x = "ws", wd = "wd", n.clust
     
   } else {
     
-    results.grid <- polarPlot(mydata,
+    results.grid <- polarPlot(mydata, 
+                              plot = FALSE,
                               pollutant = pollutant, x = x,
                               cluster = TRUE, ...
     )$data
@@ -438,20 +443,29 @@ polarCluster <- function(mydata, pollutant = "nox", x = "ws", wd = "wd", n.clust
   plt <- do.call(levelplot, levelplot.args)
 
   ## output ################################################################
-
-  if (length(type) == 1L) plot(plt) else plot(useOuterStrips(plt, strip = strip, strip.left = strip.left))
-
+  if (plot) {
+    if (length(type) == 1L)
+      plot(plt)
+    else
+      plot(useOuterStrips(plt, strip = strip, strip.left = strip.left))
+  }
   ## change cluster output to C1, C2 etc
   mydata$cluster <- paste("C", mydata$cluster, sep = "")
 
   if (is.data.frame(after)) {
-    
-    output <- list(plot = plt, data = results, after = after, call = match.call())
+    output <-
+      list(
+        plot = plt,
+        data = results,
+        after = after,
+        call = match.call()
+      )
     
   } else {
+    output <- list(plot = plt,
+                   data = results,
+                   call = match.call())
     
-  output <- list(plot = plt, data = results, call = match.call())
-  
   }
   invisible(output)
 }

--- a/R/polarDiff.R
+++ b/R/polarDiff.R
@@ -21,6 +21,9 @@
 #' @param pollutant The pollutant to analyse.
 #' @param x The variable used for the radial axis (default = "ws").
 #' @param limits The colour scale limits e.g. \code{limits = c(-10, 10)}.
+#' @param plot Should a plot be produced? \code{FALSE} can be useful when
+#'   analysing data to extract plot components and plotting them in other
+#'   ways.
 #' @param ... Other arguments to \code{\link{polarPlot}}.
 #'
 #' @return Only plot at the moment.
@@ -41,7 +44,8 @@
 #' }
 polarDiff <- function(before, after, pollutant = "nox", 
                       x = "ws",
-                      limits = NA, ...) {
+                      limits = NA, 
+                      plot = TRUE, ...) {
   
   # extra args setup
   Args <- list(...)
@@ -66,6 +70,7 @@ polarDiff <- function(before, after, pollutant = "nox",
                       pollutant = pollutant,
                       x = x, 
                       type = "period",
+                      plot = FALSE,
                       ...)
   
   polar_data <- pivot_wider(polar_plt$data, 
@@ -97,7 +102,7 @@ polarDiff <- function(before, after, pollutant = "nox",
   
   
   polarPlot(polar_data, pollutant = pollutant, 
-            x = x,
+            x = x, plot = plot,
             cols = Args$cols,
             limits = Args$limits,
             force.positive = FALSE)

--- a/R/polarPlot.R
+++ b/R/polarPlot.R
@@ -331,6 +331,10 @@
 #' @param tau The quantile to be estimated when \code{statistic} is set to
 #'   \code{"quantile.slope"}. Default is \code{0.5} which is equal to the median
 #'   and will be ignored if \code{"quantile.slope"} is not used.
+#'   
+#' @param plot Should a plot be produced? \code{FALSE} can be useful when
+#'   analysing data to extract plot components and plotting them in other
+#'   ways.
 #'
 #' @param ... Other graphical parameters passed onto \code{lattice:levelplot}
 #'   and \code{cutData}. For example, \code{polarPlot} passes the option
@@ -456,7 +460,7 @@ polarPlot <-
            key.header = "", key.footer = pollutant, key.position = "right",
            key = TRUE, auto.text = TRUE, ws_spread = 1.5, wd_spread = 5,
            x_error = NA, y_error = NA,
-           kernel = "gaussian", tau = 0.5, ...) {
+           kernel = "gaussian", tau = 0.5, plot = TRUE, ...) {
 
     ## get rid of R check annoyances
     z <- . <- NULL
@@ -1184,14 +1188,14 @@ polarPlot <-
 
     plt <- do.call(levelplot, Args)
 
-    if (length(type) == 1) {
-      plot(plt)
-    } else {
-      plot(useOuterStrips(
-        plt,
-        strip = strip,
-        strip.left = strip.left
-      ))
+    if (plot) {
+      if (length(type) == 1) {
+        plot(plt)
+      } else {
+        plot(useOuterStrips(plt,
+                            strip = strip,
+                            strip.left = strip.left))
+      }
     }
 
     newdata <- res

--- a/R/scatterPlot.R
+++ b/R/scatterPlot.R
@@ -204,6 +204,9 @@
 ##' @param auto.text Either \code{TRUE} (default) or \code{FALSE}. If
 ##'   \code{TRUE} titles and axis labels will automatically try and format
 ##'   pollutant names and units properly e.g.  by subscripting the \sQuote{2} in NO2.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other
+##'   ways.
 ##' @param ... Other graphical parameters are passed onto
 ##' \code{cutData} and an appropriate \code{lattice} plot function
 ##' (\code{xyplot}, \code{levelplot} or \code{hexbinplot} depending on
@@ -324,7 +327,7 @@ scatterPlot <- function(mydata, x = "nox", y = "no2", z = NA, method = "scatter"
                         log.x = FALSE, log.y = FALSE, x.inc = NULL, y.inc = NULL,
                         limits = NULL, windflow = NULL, y.relation = "same", x.relation = "same",
                         ref.x = NULL, ref.y = NULL, k = NA, dist = 0.02,
-                        map = FALSE, auto.text = TRUE, ...) {
+                        map = FALSE, auto.text = TRUE, plot = TRUE, ...) {
 
   ## basic function to plot single/multiple time series in flexible waysproduce scatterPlot
   ## Author: David Carslaw 27 Jan. 10
@@ -1655,11 +1658,12 @@ scatterPlot <- function(mydata, x = "nox", y = "no2", z = NA, method = "scatter"
     plt <- do.call(levelplot, levelplot.args)
   }
 
-
-  if (length(type) == 1) {
-    plot(plt)
-  } else {
-    plot(useOuterStrips(plt, strip = strip, strip.left = strip.left))
+  if (plot) {
+    if (length(type) == 1) {
+      plot(plt)
+    } else {
+      plot(useOuterStrips(plt, strip = strip, strip.left = strip.left))
+    }
   }
 
   newdata <- mydata

--- a/R/smoothTrend.R
+++ b/R/smoothTrend.R
@@ -118,6 +118,9 @@
 ##'   package \code{mgcv}. By default it is not used and the amount of smoothing
 ##'   is optimised automatically. However, sometimes it is useful to set the
 ##'   smoothing amount manually using \code{k}.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other
+##'   ways.
 ##' @param ... Other graphical parameters are passed onto \code{cutData} and
 ##'   \code{lattice:xyplot}. For example, \code{smoothTrend} passes the option
 ##'   \code{hemisphere = "southern"} on to \code{cutData} to provide southern
@@ -181,7 +184,7 @@ smoothTrend <- function(mydata, pollutant = "nox", deseason = FALSE,
                         y.relation = "same", ref.x = NULL, ref.y = NULL,
                         key.columns = length(percentile), name.pol = pollutant,
                         ci = TRUE, alpha = 0.2, date.breaks = 7,
-                        auto.text = TRUE, k = NULL, ...) {
+                        auto.text = TRUE, k = NULL, plot = TRUE, ...) {
 
   ## get rid of R check annoyances
   variable <- NULL
@@ -579,15 +582,15 @@ smoothTrend <- function(mydata, pollutant = "nox", deseason = FALSE,
     call = match.call()
   )
   class(output) <- "openair"
-
+  
   ## output ########################################################################
-  if (length(type) == 1) {
-    plot(plt)
-  } else {
-    plot(useOuterStrips(plt, strip = strip, strip.left = strip.left))
+  if (plot) {
+    if (length(type) == 1) {
+      plot(plt)
+    } else {
+      plot(useOuterStrips(plt, strip = strip, strip.left = strip.left))
+    }
   }
-
-
-
+  
   invisible(output)
 }

--- a/R/summaryPlot.R
+++ b/R/summaryPlot.R
@@ -1,120 +1,110 @@
 ##' Function to rapidly provide an overview of air quality data
 ##'
-##' This function provides a quick graphical and numerical summary of
-##' data. The location presence/absence of data are shown, with
-##' summary statistics and plots of variable distributions.
-##' \code{summaryPlot} can also provide summaries of a single
-##' pollutant across many sites.
+##' This function provides a quick graphical and numerical summary of data. The
+##' location presence/absence of data are shown, with summary statistics and
+##' plots of variable distributions. \code{summaryPlot} can also provide
+##' summaries of a single pollutant across many sites.
 ##'
 ##'
 ##' \code{summaryPlot} produces two panels of plots: one showing the
-##' presence/absence of data and the other the distributions. The left
-##' panel shows time series and codes the presence or absence of data
-##' in different colours. By stacking the plots one on top of another
-##' it is easy to compare different pollutants/variables. Overall
-##' statistics are given for each variable: mean, maximum, minimum,
-##' missing hours (also expressed as a percentage), median and the
-##' 95th percentile. For each year the data capture rate (expressed as
-##' a percentage of hours in that year) is also given.
+##' presence/absence of data and the other the distributions. The left panel
+##' shows time series and codes the presence or absence of data in different
+##' colours. By stacking the plots one on top of another it is easy to compare
+##' different pollutants/variables. Overall statistics are given for each
+##' variable: mean, maximum, minimum, missing hours (also expressed as a
+##' percentage), median and the 95th percentile. For each year the data capture
+##' rate (expressed as a percentage of hours in that year) is also given.
 ##'
-##' The right panel shows either a histogram or a density plot
-##' depending on the choice of \code{type}. Density plots avoid the
-##' issue of arbitrary bin sizes that can sometimes provide a
-##' misleading view of the data distribution.  Density plots are often
-##' more appropriate, but their effectiveness will depend on the data
-##' in question.
+##' The right panel shows either a histogram or a density plot depending on the
+##' choice of \code{type}. Density plots avoid the issue of arbitrary bin sizes
+##' that can sometimes provide a misleading view of the data distribution.
+##' Density plots are often more appropriate, but their effectiveness will
+##' depend on the data in question.
 ##'
-##' \code{summaryPlot} will only show data that are numeric or integer
-##' type.  This is useful for checking that data have been imported
-##' properly. For example, if for some reason a column representing
-##' wind speed erroneosly had one or more fields with charcters in,
-##' the whole column would be either character or factor type. The
-##' absence of a wind speed variable in the \code{summaryPlot} plot
-##' would therefore indicate a problem with the input data. In this
-##' particular case, the user should go back to the source data and
-##' remove the characters or remove them using R functions.
+##' \code{summaryPlot} will only show data that are numeric or integer type.
+##' This is useful for checking that data have been imported properly. For
+##' example, if for some reason a column representing wind speed erroneosly had
+##' one or more fields with charcters in, the whole column would be either
+##' character or factor type. The absence of a wind speed variable in the
+##' \code{summaryPlot} plot would therefore indicate a problem with the input
+##' data. In this particular case, the user should go back to the source data
+##' and remove the characters or remove them using R functions.
 ##'
-##' If there is a field \code{site}, which would generally mean there
-##' is more than one site, \code{summaryPlot} will provide information
-##' on a \emph{single} pollutant across all sites, rather than provide
-##' details on all pollutants at a \emph{single} site. In this case
-##' the user should also provide a name of a pollutant e.g.
-##' \code{pollutant = "nox"}. If a pollutant is not provided the first
-##' numeric field will automatically be chosen.
+##' If there is a field \code{site}, which would generally mean there is more
+##' than one site, \code{summaryPlot} will provide information on a
+##' \emph{single} pollutant across all sites, rather than provide details on all
+##' pollutants at a \emph{single} site. In this case the user should also
+##' provide a name of a pollutant e.g. \code{pollutant = "nox"}. If a pollutant
+##' is not provided the first numeric field will automatically be chosen.
 ##'
-##' \bold{It is strongly recommended that the \code{summaryPlot}
-##' function is applied to all new imported data sets to ensure the
-##' data are imported as expected.}
+##' \bold{It is strongly recommended that the \code{summaryPlot} function is
+##' applied to all new imported data sets to ensure the data are imported as
+##' expected.}
 ##'
-##' @param mydata A data frame to be summarised. Must contain a
-##'   \code{date} field and at least one other parameter.
-##' @param na.len Missing data are only shown with at least
-##'   \code{na.len} \emph{contiguous} missing vales. The purpose of
-##'   setting \code{na.len} is for clarity: with long time series it
-##'   is difficult to see where individual missing hours are.
-##'   Furthermore, setting \code{na.len = 96}, for example would show
-##'   where there are at least 4 days of continuous missing data.
-##' @param clip When data contain outliers, the histogram or density
-##'   plot can fail to show the distribution of the main body of data.
-##'   Setting \code{clip = TRUE}, will remove the top 1 % of data to
-##'   yield what is often a better display of the overall distribution
-##'   of the data. The amount of clipping can be set with
-##'   \code{percentile}.
+##' @param mydata A data frame to be summarised. Must contain a \code{date}
+##'   field and at least one other parameter.
+##' @param na.len Missing data are only shown with at least \code{na.len}
+##'   \emph{contiguous} missing vales. The purpose of setting \code{na.len} is
+##'   for clarity: with long time series it is difficult to see where individual
+##'   missing hours are. Furthermore, setting \code{na.len = 96}, for example
+##'   would show where there are at least 4 days of continuous missing data.
+##' @param clip When data contain outliers, the histogram or density plot can
+##'   fail to show the distribution of the main body of data. Setting \code{clip
+##'   = TRUE}, will remove the top 1 % of data to yield what is often a better
+##'   display of the overall distribution of the data. The amount of clipping
+##'   can be set with \code{percentile}.
 ##' @param percentile This is used to clip the data. For example,
-##'   \code{percentile = 0.99} (the default) will remove the top 1
-##'   percentile of values i.e. values greater than the 99th
-##'   percentile will not be used.
-##' @param type \code{type} is used to determine whether a histogram
-##'   (the default) or a density plot is used to show the distribution
-##'   of the data.
-##' @param pollutant \code{pollutant} is used when there is a field
-##'   \code{site} and there is more than one site in the data frame.
-##' @param period \code{period} is either \code{years} (the default)
-##'   or \code{months}. Statistics are calculated depending on the
-##'   \code{period} chosen.
-##' @param avg.time This defines the time period to average the time
-##'   series plots. Can be \dQuote{sec}, \dQuote{min}, \dQuote{hour},
-##'   \dQuote{day} (the default), \dQuote{week}, \dQuote{month},
-##'   \dQuote{quarter} or \dQuote{year}. For much increased
-##'   flexibility a number can precede these options followed by a
-##'   space. For example, a timeAverage of 2 months would be
-##'   \code{avg.time = "2 month"}.
+##'   \code{percentile = 0.99} (the default) will remove the top 1 percentile of
+##'   values i.e. values greater than the 99th percentile will not be used.
+##' @param type \code{type} is used to determine whether a histogram (the
+##'   default) or a density plot is used to show the distribution of the data.
+##' @param pollutant \code{pollutant} is used when there is a field \code{site}
+##'   and there is more than one site in the data frame.
+##' @param period \code{period} is either \code{years} (the default) or
+##'   \code{months}. Statistics are calculated depending on the \code{period}
+##'   chosen.
+##' @param avg.time This defines the time period to average the time series
+##'   plots. Can be \dQuote{sec}, \dQuote{min}, \dQuote{hour}, \dQuote{day} (the
+##'   default), \dQuote{week}, \dQuote{month}, \dQuote{quarter} or
+##'   \dQuote{year}. For much increased flexibility a number can precede these
+##'   options followed by a space. For example, a timeAverage of 2 months would
+##'   be \code{avg.time = "2 month"}.
 ##' @param print.datacap Should the data capture \% be shown for each period?
-##' @param breaks Number of histogram bins. Sometime useful but not
-##'   easy to set a single value for a range of very different
-##'   variables.
+##' @param breaks Number of histogram bins. Sometime useful but not easy to set
+##'   a single value for a range of very different variables.
 ##' @param plot.type The \code{lattice} plot type, which is a line
 ##'   (\code{plot.type = "l"}) by default. Another useful option is
 ##'   \code{plot.type = "h"}, which draws vertical lines.
-##' @param col.trend Colour to be used to show the monthly trend of
-##'   the data, shown as a shaded region. Type \code{colors()} into R
-##'   to see the full range of colour names.
-##' @param col.data Colour to be used to show the \emph{presence} of
-##'   data. Type \code{colors()} into R to see the full range of
-##'   colour names.
+##' @param col.trend Colour to be used to show the monthly trend of the data,
+##'   shown as a shaded region. Type \code{colors()} into R to see the full
+##'   range of colour names.
+##' @param col.data Colour to be used to show the \emph{presence} of data. Type
+##'   \code{colors()} into R to see the full range of colour names.
 ##' @param col.mis Colour to be used to show missing data.
 ##' @param col.hist Colour for the histogram or density plot.
 ##' @param cols Predefined colour scheme, currently only enabled for
 ##'   \code{"greyscale"}.
-##' @param date.breaks Number of major x-axis intervals to use. The
-##'   function will try and choose a sensible number of dates/times as
-##'   well as formatting the date/time appropriately to the range
-##'   being considered.  This does not always work as desired
-##'   automatically. The user can therefore increase or decrease the
-##'   number of intervals by adjusting the value of \code{date.breaks}
-##'   up or down.
+##' @param date.breaks Number of major x-axis intervals to use. The function
+##'   will try and choose a sensible number of dates/times as well as formatting
+##'   the date/time appropriately to the range being considered.  This does not
+##'   always work as desired automatically. The user can therefore increase or
+##'   decrease the number of intervals by adjusting the value of
+##'   \code{date.breaks} up or down.
 ##' @param auto.text Either \code{TRUE} (default) or \code{FALSE}. If
-##'   \code{TRUE} titles and axis labels will automatically try and
-##'   format pollutant names and units properly e.g.  by subscripting
-##'   the \sQuote{2} in NO2.
-##' @param ... Other graphical parameters. Commonly used examples
-##'   include the axis and title labelling options (such as
-##'   \code{xlab}, \code{ylab} and \code{main}), which are all passed
-##'   to the plot via \code{quickText} to handle routine formatting.
-##'   As \code{summaryPlot} has two components, the axis labels may be
-##'   a vector. For example, the default case (\code{type =
-##'   "histogram"}) sets y labels equivalent to \code{ylab = c("",
-##'   "Percent of Total")}.
+##'   \code{TRUE} titles and axis labels will automatically try and format
+##'   pollutant names and units properly e.g.  by subscripting the \sQuote{2} in
+##'   NO2.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other ways.
+##' @param debug Should data types be printed to the console? \code{TRUE} can be
+##'   useful for debugging.
+##' @param ... Other graphical parameters. Commonly used examples include the
+##'   axis and title labelling options (such as \code{xlab}, \code{ylab} and
+##'   \code{main}), which are all passed to the plot via \code{quickText} to
+##'   handle routine formatting. As \code{summaryPlot} has two components, the
+##'   axis labels may be a vector. For example, the default case (\code{type =
+##'   "histogram"}) sets y labels equivalent to \code{ylab = c("", "Percent of
+##'   Total")}.
 ##' @export
 ##' @author David Carslaw
 ##' @keywords methods
@@ -143,7 +133,7 @@
 ##' # show density plot line in black
 ##' \dontrun{summaryPlot(mydata, col.dens = "black")}
 ##'
-##'
+##' 
 summaryPlot <- function(mydata,
                         na.len = 24,
                         clip = TRUE,
@@ -162,6 +152,8 @@ summaryPlot <- function(mydata,
                         cols = NULL,
                         date.breaks = 7,
                         auto.text = TRUE,
+                        plot = TRUE,
+                        debug = FALSE,
                         ...) {
 
   ## get rid of R check annoyances
@@ -254,7 +246,7 @@ summaryPlot <- function(mydata,
   dateBreaks <- dateBreaks(mydata$date, date.breaks)$major
 
   ## print data types - helps with debugging
-  print(unlist(sapply(mydata, class)))
+  if (debug) print(unlist(sapply(mydata, class)))
 
   ## check to see if there is a field site and >1 site
   ## if several sites and no pollutant supplied, use first numeric
@@ -576,17 +568,17 @@ summaryPlot <- function(mydata,
     trellis.par.set("strip.background", current.strip)
   }
   
-  print(plt1, position = c(0, 0, 0.7, y.upp), more = TRUE)
-  print(plt2, position = c(0.7, 0, 1, 0.975 * y.upp))
-
-  ## use grid to add an overall title
-  grid.text(main, 0.5, y.upp, gp = gpar(fontsize = 14))
+  if (plot) {
+    print(plt1, position = c(0, 0, 0.7, y.upp), more = TRUE)
+    print(plt2, position = c(0.7, 0, 1, 0.975 * y.upp))
+    
+    ## use grid to add an overall title
+    grid.text(main, 0.5, y.upp, gp = gpar(fontsize = 14))
+  }
   
   ## create output with plot
   output <- list(plot = list(plt1, plt2), data = dummy.dat, call = match.call())
   class(output) <- "openair"
   invisible(output)
-  
-  
 }
 

--- a/R/timePlot.R
+++ b/R/timePlot.R
@@ -197,6 +197,9 @@
 ##'   \code{TRUE} titles and axis labels will automatically try and
 ##'   format pollutant names and units properly e.g.  by subscripting
 ##'   the \sQuote{2} in NO2.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other
+##'   ways.
 ##' @param ... Other graphical parameters are passed onto
 ##'   \code{cutData} and \code{lattice:xyplot}. For example,
 ##'   \code{timePlot} passes the option \code{hemisphere = "southern"}
@@ -288,7 +291,7 @@ timePlot <- function(mydata, pollutant = "nox", group = FALSE, stack = FALSE,
                      y.relation = "same", ref.x = NULL, ref.y = NULL,
                      key.columns = 1, key.position = "bottom",
                      name.pol = pollutant, date.breaks = 7,
-                     date.format = NULL, auto.text = TRUE, ...) {
+                     date.format = NULL, auto.text = TRUE, plot = TRUE, ...) {
 
 
   ## basic function to plot single/multiple time series in flexible ways
@@ -752,8 +755,8 @@ timePlot <- function(mydata, pollutant = "nox", group = FALSE, stack = FALSE,
   plt <- do.call(xyplot, xyplot.args)
 
   ## output
-
-  plot(plt)
+  
+  if (plot) plot(plt)
   newdata <- mydata
   output <- list(plot = plt, data = newdata, call = match.call())
   class(output) <- "openair"

--- a/R/timeProp.R
+++ b/R/timeProp.R
@@ -92,6 +92,9 @@
 ##'   \code{TRUE} titles and axis labels etc. will automatically try
 ##'   and format pollutant names and units properly e.g.  by
 ##'   subscripting the `2' in NO2.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other
+##'   ways.
 ##' @param ... Other graphical parameters passed onto \code{timeProp}
 ##'   and \code{cutData}. For example, \code{timeProp} passes the
 ##'   option \code{hemisphere = "southern"} on to \code{cutData} to
@@ -121,7 +124,7 @@ timeProp <- function(mydata, pollutant = "nox", proportion = "cluster",
                      normalise = FALSE, cols = "Set1", date.breaks = 7,
                      date.format = NULL, key.columns = 1,
                      key.position = "right", key.title = proportion,
-                     auto.text = TRUE, ...) {
+                     auto.text = TRUE, plot = TRUE, ...) {
 
   ## keep check happy
   sums <- NULL
@@ -348,7 +351,7 @@ timeProp <- function(mydata, pollutant = "nox", proportion = "cluster",
     x.limits = xlim, y.limits = ylim, main = main
   ))
 
-  print(plt)
+  if (plot) print(plt)
 
   invisible(trellis.last.object())
 

--- a/R/timeVariation.R
+++ b/R/timeVariation.R
@@ -164,6 +164,9 @@
 ##' @param month.last Should the order of the plots be changed so the plot 
 ##'   showing monthly means be the last plot for a logical hierarchy of 
 ##'   averaging periods?
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other
+##'   ways.
 ##' @param ... Other graphical parameters passed onto \code{lattice:xyplot} and
 ##'   \code{cutData}. For example, in the case of \code{cutData} the option
 ##'   \code{hemisphere = "southern"}.
@@ -276,7 +279,7 @@ timeVariation <- function(mydata, pollutant = "nox", local.tz = NULL,
                           type = "default", group = NULL, difference = FALSE,
                           statistic = "mean", conf.int = 0.95, B = 100, ci = TRUE, cols = "hue",
                           ref.y = NULL, key = NULL, key.columns = 1, start.day = 1,
-                          auto.text = TRUE, alpha = 0.4, month.last = FALSE, 
+                          auto.text = TRUE, alpha = 0.4, month.last = FALSE, plot = TRUE,
                           ...) {
 
   ## get rid of R check annoyances
@@ -1021,7 +1024,7 @@ timeVariation <- function(mydata, pollutant = "nox", local.tz = NULL,
     )), ...)
   }
 
-  main.plot()
+  if (plot) main.plot()
   output <- list(
     plot = list(day.hour, hour, day, month, subsets = subsets),
     data = list(data.day.hour, data.hour, data.weekday, data.month, subsets = subsets),

--- a/R/trajCluster.R
+++ b/R/trajCluster.R
@@ -26,7 +26,6 @@
 ##'   back trajectories. There are two methods available:
 ##'   \dQuote{Euclid} and \dQuote{Angle}.
 ##' @param n.cluster Number of clusters to calculate.
-##' @param plot Should a plot be produced?
 ##' @param type \code{type} determines how the data are split i.e.
 ##'   conditioned, and then plotted. The default is will produce a
 ##'   single plot using the entire data. Type can be one of the
@@ -80,6 +79,9 @@
 ##'   will make each panel add up to 100.
 ##' @param origin If \code{TRUE} a filled circle dot is shown to mark the
 ##'     receptor point.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other
+##'   ways.
 ##' @param ... Other graphical parameters passed onto
 ##'   \code{lattice:levelplot} and \code{cutData}. Similarly, common
 ##'   axis and title labelling options (such as \code{xlab},
@@ -113,22 +115,22 @@
 ##' traj <- trajCluster(traj, method = "Angle", type = "season", n.cluster = 4)
 ##' }
 trajCluster <- function(traj, method = "Euclid", n.cluster = 5,
-                        plot = TRUE, type = "default",
+                        type = "default",
                         cols = "Set1", split.after = FALSE, map.fill = TRUE,
                         map.cols = "grey40", map.alpha = 0.4,
                         projection = "lambert",
                         parameters = c(51, 51), orientation = c(90, 0, 0),
-                        by.type = FALSE, origin = TRUE, ...) {
-
+                        by.type = FALSE, origin = TRUE, plot = TRUE, ...) {
+  
   # silence R check
   freq <- hour.inc <- default <- NULL
-
+  
   if (tolower(method) == "euclid") {
     method <- "distEuclid"
   } else {
     method <- "distAngle"
   }
-
+  
   # remove any missing lat/lon
   traj <- filter(traj, !is.na(lat), !is.na(lon))
   
@@ -145,17 +147,17 @@ trajCluster <- function(traj, method = "Euclid", n.cluster = 5,
   }
   
   Args <- list(...)
-
+  
   ## set graphics
   current.strip <- trellis.par.get("strip.background")
   current.font <- trellis.par.get("fontsize")
-
+  
   ## reset graphic parameters
   on.exit(trellis.par.set(
-     
+    
     fontsize = current.font
   ))
-
+  
   ## label controls
   Args$plot.type <- if ("plot.type" %in% names(Args)) {
     Args$plot.type
@@ -167,65 +169,65 @@ trajCluster <- function(traj, method = "Euclid", n.cluster = 5,
   } else {
     Args$lwd <- 4
   }
-
+  
   if ("fontsize" %in% names(Args)) {
     trellis.par.set(fontsize = list(text = Args$fontsize))
   }
-
+  
   calcTraj <- function(traj) {
-
+    
     ## make sure ordered correctly
     traj <- traj[order(traj$date, traj$hour.inc), ]
-
+    
     ## length of back trajectories
     traj <- group_by(traj, date) %>%
       mutate(len = length(date))
-
+    
     ## find length of back trajectories
     ## 96-hour back trajectories with origin: length should be 97
     n <- max(abs(traj$hour.inc)) + 1
-
+    
     traj <- subset(traj, len == n)
     len <- nrow(traj) / n
-
+    
     ## lat/lon input matrices
     x <- matrix(traj$lon, nrow = n)
     y <- matrix(traj$lat, nrow = n)
-
+    
     z <- matrix(0, nrow = n, ncol = len)
     res <- matrix(0, nrow = len, ncol = len)
-
+    
     if (method == "distEuclid") {
       res <- .Call("distEuclid", x, y, res)
     }
-
+    
     if (method == "distAngle") {
       res <- .Call("distAngle", x, y, res)
     }
-
+    
     res[is.na(res)] <- 0 ## possible for some to be NA if trajectory does not move between two hours?
-
+    
     dist.res <- as.dist(res)
     clusters <- pam(dist.res, n.cluster)
     cluster <- rep(clusters$clustering, each = n)
     traj$cluster <- as.character(paste("C", cluster, sep = ""))
     traj
   }
-
+  
   ## this bit decides whether to separately calculate trajectories for each level of type
-
+  
   if (split.after) {
     traj <- group_by(traj, default) %>%
       do(calcTraj(.))
     traj <- cutData(traj, type)
   } else {
     traj <- cutData(traj, type)
-
+    
     traj <- traj %>% 
       group_by(across(type)) %>%
       do(calcTraj(.))
   }
-
+  
   # trajectory origin
   origin_xy <- head(subset(traj, hour.inc == 0), 1) ## origin
   tmp <- mapproject(
@@ -236,92 +238,90 @@ trajCluster <- function(traj, method = "Euclid", n.cluster = 5,
     orientation = orientation
   )
   receptor <- c(tmp$x, tmp$y)
-
-  if (plot) {
-    ## calculate the mean trajectories by cluster
-
-    vars <- c("lat", "lon", "date", "cluster", "hour.inc", type)
-    vars2 <- c("cluster", "hour.inc", type)
-
-    agg <- select(traj, vars) %>%
-      group_by(across(vars2)) %>%
-      summarise(across(everything(), mean))
-
-    # the data frame we want to return before it is transformed
-    resRtn <- agg
-
-    ## proportion of total clusters
-
-    vars <- c(type, "cluster")
-
-    clusters <- traj %>% 
-      group_by(across(vars)) %>%
-      tally() %>%
-      mutate(freq = round(100 * n / sum(n), 1))
-
-    ## make each panel add up to 100
-    if (by.type) {
-      clusters <- clusters %>% 
-        group_by(across(type)) %>%
-        mutate(freq = 100 * freq / sum(freq))
-
-      clusters$freq <- round(clusters$freq, 1)
-    }
-
-    ## make sure date is in correct format
-    class(agg$date) <- class(traj$date)
-    attr(agg$date, "tzone") <- "GMT"
-
-    ## xlim and ylim set by user
-    if (!"xlim" %in% names(Args)) {
-      Args$xlim <- range(agg$lon)
-    }
-
-    if (!"ylim" %in% names(Args)) {
-      Args$ylim <- range(agg$lat)
-    }
-
-    ## extent of data (or limits set by user) in degrees
-    trajLims <- c(Args$xlim, Args$ylim)
-
-    ## need *outline* of boundary for map limits
-    Args <- setTrajLims(traj, Args, projection, parameters, orientation)
-
-    ## transform data for map projection
-    tmp <- mapproject(
-      x = agg[["lon"]],
-      y = agg[["lat"]],
-      projection = projection,
-      parameters = parameters,
-      orientation = orientation
-    )
-    agg[["lon"]] <- tmp$x
-    agg[["lat"]] <- tmp$y
-
-    plot.args <- list(
-      agg,
-      x = "lon", y = "lat", group = "cluster",
-      col = cols, type = type, map = TRUE, map.fill = map.fill,
-      map.cols = map.cols, map.alpha = map.alpha,
-      projection = projection, parameters = parameters,
-      orientation = orientation, traj = TRUE, trajLims = trajLims,
-      clusters = clusters, receptor = receptor,
-      origin = origin
-    )
-
-    ## reset for Args
-    plot.args <- listUpdate(plot.args, Args)
-
-    ## plot
-    plt <- do.call(scatterPlot, plot.args)
+  
+  ## calculate the mean trajectories by cluster
+  
+  vars <- c("lat", "lon", "date", "cluster", "hour.inc", type)
+  vars2 <- c("cluster", "hour.inc", type)
+  
+  agg <- select(traj, vars) %>%
+    group_by(across(vars2)) %>%
+    summarise(across(everything(), mean))
+  
+  # the data frame we want to return before it is transformed
+  resRtn <- agg
+  
+  ## proportion of total clusters
+  
+  vars <- c(type, "cluster")
+  
+  clusters <- traj %>% 
+    group_by(across(vars)) %>%
+    tally() %>%
+    mutate(freq = round(100 * n / sum(n), 1))
+  
+  ## make each panel add up to 100
+  if (by.type) {
+    clusters <- clusters %>% 
+      group_by(across(type)) %>%
+      mutate(freq = 100 * freq / sum(freq))
     
-    ## create output with plot
-    output <- list(plot = plt, data = list(traj = traj, results = resRtn), call = match.call())
-    class(output) <- "openair"
-    invisible(output)
-  } else {
-    ## create output without plot
-    return(traj)
+    clusters$freq <- round(clusters$freq, 1)
   }
-
+  
+  ## make sure date is in correct format
+  class(agg$date) <- class(traj$date)
+  attr(agg$date, "tzone") <- "GMT"
+  
+  ## xlim and ylim set by user
+  if (!"xlim" %in% names(Args)) {
+    Args$xlim <- range(agg$lon)
+  }
+  
+  if (!"ylim" %in% names(Args)) {
+    Args$ylim <- range(agg$lat)
+  }
+  
+  ## extent of data (or limits set by user) in degrees
+  trajLims <- c(Args$xlim, Args$ylim)
+  
+  ## need *outline* of boundary for map limits
+  Args <- setTrajLims(traj, Args, projection, parameters, orientation)
+  
+  ## transform data for map projection
+  tmp <- mapproject(
+    x = agg[["lon"]],
+    y = agg[["lat"]],
+    projection = projection,
+    parameters = parameters,
+    orientation = orientation
+  )
+  agg[["lon"]] <- tmp$x
+  agg[["lat"]] <- tmp$y
+  
+  plot.args <- list(
+    agg,
+    x = "lon", y = "lat", group = "cluster",
+    col = cols, type = type, map = TRUE, map.fill = map.fill,
+    map.cols = map.cols, map.alpha = map.alpha,
+    projection = projection, parameters = parameters,
+    orientation = orientation, traj = TRUE, trajLims = trajLims,
+    clusters = clusters, receptor = receptor,
+    origin = origin
+  )
+  
+  ## reset for Args
+  plot.args <- listUpdate(plot.args, Args)
+  
+  plot.args <- listUpdate(plot.args, list(plot = plot))
+  
+  ## plot
+  plt <- do.call(scatterPlot, plot.args)
+  
+  ## create output with plot
+  output <- list(plot = plt, data = list(traj = traj, results = resRtn), call = match.call())
+  class(output) <- "openair"
+  invisible(output)
+  
+  
 }

--- a/R/trajLevel.R
+++ b/R/trajLevel.R
@@ -566,7 +566,7 @@ trajLevel <- function(mydata, lon = "lon", lat = "lat",
   ## plot
   do.call(scatterPlot, scatterPlot.args)
   
-  output <- list(data = mydata, call = match.call())
+  output <- list(plot = plt$plot, data = mydata, call = match.call())
   class(output) <- "openair"
   
   invisible(output)

--- a/R/trajLevel.R
+++ b/R/trajLevel.R
@@ -159,6 +159,9 @@
 ##' @param grid.col The colour of the map grid to be used. To remove the grid
 ##'   set \code{grid.col = "transparent"}.
 ##' @param origin should the receptor origin be shown by a black dot?
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other
+##'   ways.
 ##' @param ... other arguments are passed to \code{cutData} and
 ##'   \code{scatterPlot}. This provides access to arguments used in both these
 ##'   functions and functions that they in turn pass arguments on to. For
@@ -224,7 +227,7 @@ trajLevel <- function(mydata, lon = "lon", lat = "lat",
                       map.fill = TRUE, map.res = "default", map.cols = "grey40",
                       map.alpha = 0.3, projection = "lambert",
                       parameters = c(51, 51), orientation = c(90, 0, 0),
-                      grid.col = "deepskyblue", origin = TRUE, ...) {
+                      grid.col = "deepskyblue", origin = TRUE, plot = TRUE, ...) {
   
   ## mydata can be a list of several trajectory files; in which case combine them
   ## before averaging
@@ -562,9 +565,10 @@ trajLevel <- function(mydata, lon = "lon", lat = "lat",
   
   ## reset for Args
   scatterPlot.args <- listUpdate(scatterPlot.args, Args)
+  scatterPlot.args <- listUpdate(scatterPlot.args, list(plot = plot))
   
   ## plot
-  do.call(scatterPlot, scatterPlot.args)
+  plt <- do.call(scatterPlot, scatterPlot.args)
   
   output <- list(plot = plt$plot, data = mydata, call = match.call())
   class(output) <- "openair"

--- a/R/trendLevel.R
+++ b/R/trendLevel.R
@@ -122,6 +122,9 @@
 ##'   default, \code{TRUE}, excludes these empty panels from the plot. The
 ##'   alternative \code{FALSE} plots all \code{type} panels.
 ##' @param col.na Colour to be used to show missing data.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other
+##'   ways.
 ##' @param ...  Addition options are passed on to \code{cutData} for
 ##'   \code{type} handling and \code{levelplot} in \code{lattice} for finer
 ##'   control of the plot itself.
@@ -177,7 +180,7 @@ trendLevel <- function(mydata, pollutant = "nox", x = "month", y = "hour",
                        breaks = NA,
                        statistic = c("mean", "max", "frequency"),
                        stat.args = NULL, stat.safe.mode = TRUE, drop.unused.types = TRUE,
-                       col.na = "white",
+                       col.na = "white", plot = TRUE, 
                        ...) {
 
   ## greyscale handling
@@ -682,7 +685,7 @@ trendLevel <- function(mydata, pollutant = "nox", x = "month", y = "hour",
   ## ############################
   ## openair output
   ## ############################
-  plot(plt)
+  if (plot) plot(plt)
 
   output <- list(plot = plt, data = newdata, call = match.call())
   class(output) <- "openair"

--- a/R/windRose.R
+++ b/R/windRose.R
@@ -84,22 +84,6 @@ pollutionRose <- function(mydata, pollutant = "nox", key.footer = pollutant,
 ##' direction bias is colour-coded to show negative bias in one colour
 ##' and positive bias in another.
 ##'
-##' @usage windRose(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
-##'   ws.int = 2, angle = 30, type = "default", bias.corr = TRUE, cols
-##'   = "default", grid.line = NULL, width = 1, seg = NULL, auto.text
-##'   = TRUE, breaks = 4, offset = 10, normalise = FALSE, max.freq =
-##'   NULL, paddle = TRUE, key.header = NULL, key.footer = "(m/s)",
-##'   key.position = "bottom", key = TRUE, dig.lab = 5, include.lowest = FALSE,
-##'   statistic =
-##'   "prop.count", pollutant = NULL, annotate = TRUE, angle.scale =
-##'   315, border = NA, ...)
-##'
-##'
-##'   pollutionRose(mydata, pollutant = "nox", key.footer = pollutant,
-##'   key.position = "right", key = TRUE, breaks = 6, paddle = FALSE,
-##'   seg = 0.9, normalise = FALSE, ...)
-##'
-##'
 ##' @aliases windRose pollutionRose
 ##' @param mydata A data frame containing fields \code{ws} and
 ##'   \code{wd}

--- a/R/windRose.R
+++ b/R/windRose.R
@@ -1,22 +1,23 @@
 pollutionRose <- function(mydata, pollutant = "nox", key.footer = pollutant,
                           key.position = "right", key = TRUE,
                           breaks = 6, paddle = FALSE, seg = 0.9, normalise = FALSE,
+                          plot = TRUE,
                           ...) {
-
+  
   ## extra args setup
   extra <- list(...)
-
+  
   ## check to see if two met data sets are being compared.
   ## if so, set pollutant to one of the names
   if ("ws2" %in% names(extra)) {
     pollutant <- extra$ws
     if (missing(breaks)) breaks <- NA
   }
-
+  
   if (is.null(breaks)) breaks <- 6
-
+  
   if (is.numeric(breaks) & length(breaks) == 1) {
-
+    
     ## breaks from the minimum to 90th percentile, which generally gives sensible
     ## spacing for skewed data. Maximum is added later.
     breaks <- unique(pretty(c(
@@ -25,12 +26,12 @@ pollutionRose <- function(mydata, pollutant = "nox", key.footer = pollutant,
       breaks
     ))
   }
-
+  
   windRose(
     mydata,
     pollutant = pollutant, paddle = paddle, seg = seg,
     key.position = key.position, key.footer = key.footer, key = key,
-    breaks = breaks, normalise = normalise, ...
+    breaks = breaks, normalise = normalise, plot = plot, ...
   )
 }
 
@@ -218,6 +219,9 @@ pollutionRose <- function(mydata, pollutant = "nox", key.footer = pollutant,
 ##'   direction.
 ##' @param border Border colour for shaded areas. Default is no
 ##'   border.
+##' @param plot Should a plot be produced? \code{FALSE} can be useful when
+##'   analysing data to extract plot components and plotting them in other
+##'   ways.
 ##' @param ... For \code{pollutionRose} other parameters that are
 ##'   passed on to \code{windRose}. For \code{windRose} other
 ##'   parameters that are passed on to \code{drawOpenKey},
@@ -326,9 +330,10 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
                      key.footer = "(m/s)", key.position = "bottom",
                      key = TRUE, dig.lab = 5, include.lowest = FALSE, statistic = "prop.count",
                      pollutant = NULL, annotate = TRUE, angle.scale = 315, border = NA,
+                     plot = TRUE,
                      ...) {
   if (is.null(seg)) seg <- 0.9
-
+  
   ## greyscale handling
   if (length(cols) == 1 && cols == "greyscale") {
     trellis.par.set(list(strip.background = list(col = "white")))
@@ -337,20 +342,20 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
   } else {
     calm.col <- "forestgreen"
   }
-
+  
   ## set graphics
   current.strip <- trellis.par.get("strip.background")
   current.font <- trellis.par.get("fontsize")
-
+  
   ## reset graphic parameters
   on.exit(trellis.par.set(
-     
+    
     fontsize = current.font
   ))
-
+  
   # make sure ws and wd and numeric
   mydata <- checkNum(mydata, vars = c(ws, wd))
-
+  
   if (360 / angle != round(360 / angle)) {
     warning(
       "In windRose(...):\n  angle will produce some spoke overlap",
@@ -366,10 +371,10 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
     )
     angle <- 3
   }
-
+  
   ## extra args setup
   extra <- list(...)
-
+  
   ## label controls
   extra$xlab <- if ("xlab" %in% names(extra)) {
     quickText(extra$xlab, auto.text)
@@ -386,18 +391,18 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
   } else {
     quickText("", auto.text)
   }
-
+  
   if ("fontsize" %in% names(extra)) {
     trellis.par.set(fontsize = list(text = extra$fontsize))
   }
-
-
+  
+  
   ## preset statitistics
-
+  
   if (is.character(statistic)) {
     ## allowed cases
     ok.stat <- c("prop.count", "prop.mean", "abs.count", "frequency")
-
+    
     if (!is.character(statistic) || !statistic[1] %in% ok.stat) {
       warning(
         "In windRose(...):\n  statistic unrecognised",
@@ -406,7 +411,7 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
       )
       statistic <- "prop.count"
     }
-
+    
     if (statistic == "prop.count") {
       stat.fun <- length
       stat.unit <- "%"
@@ -416,7 +421,7 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
       stat.lab2 <- "mean"
       stat.labcalm <- function(x) round(x, 1)
     }
-
+    
     if (statistic == "prop.mean") {
       stat.fun <- function(x) sum(x, na.rm = TRUE)
       stat.unit <- "%"
@@ -426,7 +431,7 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
       stat.lab2 <- "mean"
       stat.labcalm <- function(x) round(x, 1)
     }
-
+    
     if (statistic == "abs.count" | statistic == "frequency") {
       stat.fun <- length
       stat.unit <- ""
@@ -437,17 +442,17 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
       stat.labcalm <- function(x) round(x, 0)
     }
   }
-
+  
   if (is.list(statistic)) {
-
+    
     ## IN DEVELOPMENT
-
+    
     ## this section has no testing/protection
     ## but allows users to supply a function
     ## scale it by total data or panel
     ## convert proportions to percentage
     ## label it
-
+    
     stat.fun <- statistic$fun
     stat.unit <- statistic$unit
     stat.scale <- statistic$scale
@@ -456,13 +461,13 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
     stat.lab2 <- statistic$lab2
     stat.labcalm <- statistic$labcalm
   }
-
+  
   ## variables we need
   vars <- c(wd, ws)
-
+  
   diff <- FALSE ## i.e. not two sets of ws/wd
   rm.neg <- TRUE ## will remove negative ws in check.prep
-
+  
   ## case where two met data sets are to be compared
   if (!is.na(ws2) & !is.na(wd2)) {
     vars <- c(vars, ws2, wd2)
@@ -470,11 +475,11 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
     rm.neg <- FALSE
     mydata$ws <- mydata[[ws2]] - mydata[[ws]]
     mydata$wd <- mydata[[wd2]] - mydata[[wd]]
-
+    
     ## fix negative wd
     id <- which(mydata$wd < 0)
     if (length(id) > 0) mydata$wd[id] <- mydata$wd[id] + 360
-
+    
     pollutant <- "ws"
     key.footer <- "ws"
     wd <- "wd"
@@ -490,52 +495,52 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
       ))))
       breaks <- c(-1 * max.br, 0, max.br)
     }
-
+    
     if (missing(cols)) cols <- c("lightskyblue", "tomato")
     seg <- 1
   }
-
+  
   if (any(type %in% dateTypes)) vars <- c(vars, "date")
-
+  
   if (!is.null(pollutant)) vars <- c(vars, pollutant)
-
+  
   mydata <- cutData(mydata, type, ...)
-
-
+  
+  
   mydata <- checkPrep(mydata, vars, type, remove.calm = FALSE, remove.neg = rm.neg)
-
+  
   # original data to use later
   mydata_orig <- mydata
-
+  
   # remove lines where ws is missing
   # wd can be NA and ws 0 (calm)
   id <- which(is.na(mydata[[ws]]))
-
+  
   if (length(id) > 0) {
     mydata <- mydata[-id, ]
   }
-
+  
   if (is.null(pollutant)) pollutant <- ws
-
+  
   mydata$x <- mydata[[pollutant]]
-
+  
   mydata[[wd]] <- angle * ceiling(mydata[[wd]] / angle - 0.5)
   mydata[[wd]][mydata[[wd]] == 0] <- 360
-
+  
   ## flag calms as negatives
   mydata[[wd]][mydata[, ws] == 0] <- -999 ## set wd to flag where there are calms
   ## do after rounding or -999 changes
-
+  
   if (length(breaks) == 1) breaks <- 0:(breaks - 1) * ws.int
-
+  
   if (max(breaks) < max(mydata$x, na.rm = TRUE)) {
     breaks <- c(breaks, max(mydata$x, na.rm = TRUE))
   }
-
+  
   if (min(breaks) > min(mydata$x, na.rm = TRUE)) {
     warning("Some values are below minimum break.")
   }
-
+  
   breaks <- unique(breaks)
   mydata$x <- cut(
     mydata$x,
@@ -543,17 +548,17 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
     include.lowest = include.lowest,
     dig.lab = dig.lab
   )
-
+  
   ## clean up cut intervals
   labs <- gsub("[(]|[)]|[[]|[]]", "", levels(mydata$x))
   labs <- gsub("[,]", " to ", labs)
-
-
-
+  
+  
+  
   ## statistic handling
-
+  
   prepare.grid <- function(mydata) {
-
+    
     ## these are all calms...
     if (all(is.na(mydata$x))) {
       weights <- tibble(
@@ -562,46 +567,46 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
       )
     } else {
       levels(mydata$x) <- c(paste("Interval", 1:length(labs), sep = ""))
-
+      
       all <- stat.fun(mydata[[wd]])
       calm <- mydata[mydata[[wd]] == -999, ][[pollutant]]
-
+      
       calm <- stat.fun(calm)
-
+      
       weights <- tapply(
         mydata[[pollutant]], list(mydata[[wd]], mydata$x),
         stat.fun
       )
-
+      
       freqs <- tapply(mydata[[pollutant]], mydata[[wd]], length)
-
+      
       ## scaling
       if (stat.scale == "all") {
         calm <- calm / all
         weights <- weights / all
       }
-
+      
       if (stat.scale == "panel") {
         temp <- stat.fun(stat.fun(weights)) + calm
         calm <- calm / temp
         weights <- weights / temp
       }
-
+      
       weights[is.na(weights)] <- 0
       weights <- t(apply(weights, 1, cumsum))
-
+      
       if (stat.scale == "all" | stat.scale == "panel") {
         weights <- weights * 100
         calm <- calm * 100
       }
-
+      
       panel.fun <- stat.fun2(mydata[[pollutant]])
-
+      
       ## calculate mean wd - useful for cases comparing two met data sets
       u <- mean(sin(2 * pi * mydata[[wd]] / 360), na.rm = TRUE)
       v <- mean(cos(2 * pi * mydata[[wd]] / 360), na.rm = TRUE)
       mean.wd <- atan2(u, v) * 360 / 2 / pi
-
+      
       if (all(is.na(mean.wd))) {
         mean.wd <- NA
       } else {
@@ -609,7 +614,7 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
         ## show as a negative (bias)
         if (mean.wd > 180) mean.wd <- mean.wd - 360
       }
-
+      
       weights <- bind_cols(
         as_tibble(weights),
         tibble(
@@ -619,10 +624,10 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
         )
       )
     }
-
+    
     weights
   }
-
+  
   if (paddle) {
     poly <- function(wd, len1, len2, width, colour, x.off = 0, y.off = 0) {
       theta <- wd * pi / 180
@@ -647,7 +652,7 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
                      y.off = 0) {
       len1 <- len1 + off.set
       len2 <- len2 + off.set
-
+      
       theta <- seq(
         (wd - seg * angle / 2), (wd + seg * angle / 2),
         length.out = (angle - 2) * 10
@@ -661,23 +666,23 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
       lpolygon(c(x1, x2), c(y1, y2), col = colour, border = border)
     }
   }
-
-
+  
+  
   results <- mydata %>% 
     group_by(across(type)) %>%
     do(prepare.grid(.))
-
+  
   ## format
   results$calm <- stat.labcalm(results$calm)
   results$mean.wd <- stat.labcalm(results$mean.wd)
-
+  
   # function to correct bias
   corr_bias <- function(results) {
-
+    
     # check to see if data for this type combination are rounded to 10 degrees
     wd_select <- inner_join(mydata_orig, results[1, type], by = type)
     if (!all(wd_select[[wd]] %% 10 == 0, na.rm = TRUE)) return(results)
-
+    
     wds <- seq(10, 360, 10)
     tmp <- angle * ceiling(wds / angle - 0.5)
     id <- which(tmp == 0)
@@ -690,54 +695,54 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
     
     if (n_data > 0) {
       
-    results[results[["wd"]] != -999, vars] <-
-      results[results[["wd"]] != -999, vars] * mean(tmp) / tmp
+      results[results[["wd"]] != -999, vars] <-
+        results[results[["wd"]] != -999, vars] * mean(tmp) / tmp
     }
     
     return(results)
   }
-
+  
   ## correction for bias when angle does not divide exactly into 360
   if (bias.corr) {
     results <- results %>% 
       group_by(across(type)) %>%
       do(corr_bias(.))
   }
-
-
-
+  
+  
+  
   ## proper names of labelling###########################################
   strip.dat <- strip.fun(results, type, auto.text)
   strip <- strip.dat[[1]]
   strip.left <- strip.dat[[2]]
   pol.name <- strip.dat[[3]]
-
+  
   if (length(labs) < length(cols)) {
     col <- cols[1:length(labs)]
   } else {
     col <- openColours(cols, length(labs))
   }
-
+  
   ## normalise by sector
-
+  
   if (normalise) {
     vars <- grep("Interval[1-9]", names(results))
-
+    
     ## original frequencies, so we can plot the wind frequency line
     results$freq <- results[[max(vars)]]
-
+    
     results$freq <- ave(results$freq, results[type], FUN = function(x) x / sum(x))
-
+    
     ## scale by maximum frequency
     results$norm <- results$freq / max(results$freq)
-
+    
     ## normalise
     results[, vars] <- results[, vars] / results[[max(vars)]]
-
+    
     stat.lab <- "Normalised by wind sector"
     stat.unit <- ""
   }
-
+  
   if (is.null(max.freq)) {
     max.freq <- max(
       results[results$wd != -999, grep("Interval", names(results))],
@@ -746,14 +751,14 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
   } else {
     max.freq <- max.freq
   }
-
+  
   off.set <- max.freq * (offset / 100)
   box.widths <- seq(
     0.002 ^ 0.25, 0.016 ^ 0.25,
     length.out = length(labs)
   ) ^ 4
   box.widths <- box.widths * max.freq * angle / 5
-
+  
   ## key, colorkey, legend
   legend <- list(
     col = col, space = key.position, auto.text = auto.text,
@@ -761,32 +766,32 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
     height = 0.60, width = 1.5, fit = "scale",
     plot.style = if (paddle) "paddle" else "other"
   )
-
+  
   legend <- makeOpenKeyLegend(key, legend, "windRose")
-
-
+  
+  
   temp <- paste(type, collapse = "+")
   myform <- formula(paste("Interval1 ~ wd | ", temp, sep = ""))
-
+  
   # maximum annotation that covers the data
   mymax <- max(pretty(c(0, max.freq), 4))
   
   # check to see if grid.line is a list or not and set grid line properties
   grid.value <- NULL
-
+  
   if (is.list(grid.line)) {
     if (is.null(grid.line[["value"]])) {
       grid.value <- NULL
     } else {
       grid.value <- grid.line[["value"]]
     }
-
+    
     if (is.null(grid.line[["lty"]])) {
       grid.lty <- 1
     } else {
       grid.lty <- grid.line[["lty"]]
     }
-
+    
     if (is.null(grid.line[["col"]])) {
       grid.col <- "grey85"
     } else {
@@ -797,14 +802,14 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
     grid.lty <- 1
     grid.col <- "grey85"
   }
-
+  
   myby <- if (is.null(grid.value)) pretty(c(0, mymax), 4)[2] else grid.value
-
+  
   if (myby / mymax > 0.9) myby <- mymax * 0.9
-
+  
   is_annotated <- !(annotate %in% c(FALSE, NA, NaN)) &&   !is.null(annotate)
   if (is_annotated) sub <- stat.lab else sub <- NULL
-
+  
   xy.args <- list(
     x = myform,
     xlim = 1.03 * c(-max.freq - off.set, max.freq + off.set),
@@ -818,17 +823,17 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
     aspect = 1,
     par.strip.text = list(cex = 0.8),
     scales = list(draw = FALSE),
-
+    
     panel = function(x, y, subscripts, ...) {
       panel.xyplot(x, y, ...)
       angles <- seq(0, 2 * pi, length = 360)
       sapply(
         seq(off.set, mymax + off.set, by = myby),
         function(x) llines(
-            x * sin(angles), x * cos(angles),
-            col = grid.col, lwd = 1,
-            lty = grid.lty
-          )
+          x * sin(angles), x * cos(angles),
+          col = grid.col, lwd = 1,
+          lty = grid.lty
+        )
       )
       
       dat <- results[subscripts, ] ## subset of data
@@ -899,9 +904,9 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
           
           annotate <- c("mean_ws" , "mean_wd")
           annotations_to_place <- paste0(
-          mean_ws = paste("mean ws = ", round(as.numeric(dat$panel.fun[1]), 1)),
-          "\n",
-          mean_wd = paste("mean wd = ", round(dat$mean.wd[1], 1))
+            mean_ws = paste("mean ws = ", round(as.numeric(dat$panel.fun[1]), 1)),
+            "\n",
+            mean_wd = paste("mean wd = ", round(dat$mean.wd[1], 1))
           )
         }
         
@@ -933,13 +938,14 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
   
   ## output ################################################################################
   
-  if (length(type) == 1) {
-    plot(plt)
-  } else {
-    plt <- useOuterStrips(plt, strip = strip, strip.left = strip.left)
-    plot(plt)
+  if (plot) {
+    if (length(type) == 1) {
+      plot(plt)
+    } else {
+      plt <- useOuterStrips(plt, strip = strip, strip.left = strip.left)
+      plot(plt)
+    }
   }
-  
   
   newdata <- results
   

--- a/man/TheilSen.Rd
+++ b/man/TheilSen.Rd
@@ -170,7 +170,7 @@ have more control. For format types see \code{strptime}. For
 example, to format the date like \dQuote{Jan-2012} set
 \code{date.format = "\%b-\%Y"}.}
 
-\item{plot}{Should a plot be produced. \code{FALSE} can be useful when
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract trend components and plotting them in other
 ways.}
 

--- a/man/calendarPlot.Rd
+++ b/man/calendarPlot.Rd
@@ -31,6 +31,7 @@ calendarPlot(
   key.position = "right",
   key = TRUE,
   auto.text = TRUE,
+  plot = TRUE,
   ...
 )
 }
@@ -141,6 +142,10 @@ and \code{"left"}.}
 \item{auto.text}{Either \code{TRUE} (default) or \code{FALSE}. If
 \code{TRUE} titles and axis labels will automatically try and format
 pollutant names and units properly e.g.  by subscripting the `2' in NO2.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract calendar plot components and plotting them in
+other ways.}
 
 \item{...}{Other graphical parameters are passed onto the \code{lattice}
 function \code{lattice:levelplot}, with common axis and title labelling

--- a/man/corPlot.Rd
+++ b/man/corPlot.Rd
@@ -16,6 +16,7 @@ corPlot(
   r.thresh = 0.8,
   text.col = c("black", "black"),
   auto.text = TRUE,
+  plot = TRUE,
   ...
 )
 }
@@ -69,6 +70,10 @@ second positive.}
 \item{auto.text}{Either \code{TRUE} (default) or \code{FALSE}. If
 \code{TRUE} titles and axis labels will automatically try and format
 pollutant names and units properly e.g.  by subscripting the `2' in NO2.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract corPlot components and plotting them in other
+ways.}
 
 \item{...}{Other graphical parameters passed onto \code{lattice:levelplot},
 with common axis and title labelling options (such as \code{xlab},

--- a/man/linearRelation.Rd
+++ b/man/linearRelation.Rd
@@ -16,6 +16,7 @@ linearRelation(
   auto.text = TRUE,
   cols = "grey30",
   date.breaks = 5,
+  plot = TRUE,
   ...
 )
 }
@@ -75,6 +76,10 @@ being considered.  This does not always work as desired
 automatically. The user can therefore increase or decrease the
 number of intervals by adjusting the value of
 \code{date.breaks} up or down.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{Other graphical parameters. A useful one to remove the
 strip with the date range on at the top of the plot is to set

--- a/man/percentileRose.Rd
+++ b/man/percentileRose.Rd
@@ -26,6 +26,7 @@ percentileRose(
   key.footer = "percentile",
   key.position = "bottom",
   key = TRUE,
+  plot = TRUE,
   ...
 )
 }
@@ -130,6 +131,10 @@ Allowed arguments currently include \code{"top"},
 
 \item{key}{Fine control of the scale key via \code{drawOpenKey}.
 See \code{drawOpenKey} for further details.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{Other graphical parameters are passed onto
 \code{cutData} and \code{lattice:xyplot}. For example,

--- a/man/polarAnnulus.Rd
+++ b/man/polarAnnulus.Rd
@@ -27,6 +27,7 @@ polarAnnulus(
   key.position = "right",
   key = TRUE,
   auto.text = TRUE,
+  plot = TRUE,
   ...
 )
 }
@@ -199,6 +200,10 @@ Allowed arguments currently include \dQuote{top}, \dQuote{right},
 \code{TRUE} titles and axis labels will automatically try and format
 pollutant names and units properly e.g.  by subscripting the \sQuote{2}
 in NO2.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{Other graphical parameters passed onto \code{lattice:levelplot}
 and \code{cutData}. For example, \code{polarAnnulus} passes the option

--- a/man/polarCluster.Rd
+++ b/man/polarCluster.Rd
@@ -15,6 +15,7 @@ polarCluster(
   angle.scale = 315,
   units = x,
   auto.text = TRUE,
+  plot = TRUE,
   ...
 )
 }
@@ -64,6 +65,10 @@ direction.}
 \item{auto.text}{Either \code{TRUE} (default) or \code{FALSE}. If
 \code{TRUE} titles and axis labels will automatically try and format
 pollutant names and units properly e.g.  by subscripting the `2' in NO2.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{Other graphical parameters passed onto \code{polarPlot},
 \code{lattice:levelplot} and \code{cutData}. Common axis and title

--- a/man/polarDiff.Rd
+++ b/man/polarDiff.Rd
@@ -4,7 +4,15 @@
 \alias{polarDiff}
 \title{Polar plots considering changes in concentrations between two time periods}
 \usage{
-polarDiff(before, after, pollutant = "nox", x = "ws", limits = NA, ...)
+polarDiff(
+  before,
+  after,
+  pollutant = "nox",
+  x = "ws",
+  limits = NA,
+  plot = TRUE,
+  ...
+)
 }
 \arguments{
 \item{before}{A data frame that represents the "before" case. See
@@ -18,6 +26,10 @@ polarDiff(before, after, pollutant = "nox", x = "ws", limits = NA, ...)
 \item{x}{The variable used for the radial axis (default = "ws").}
 
 \item{limits}{The colour scale limits e.g. \code{limits = c(-10, 10)}.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{Other arguments to \code{\link{polarPlot}}.}
 }

--- a/man/polarFreq.Rd
+++ b/man/polarFreq.Rd
@@ -24,6 +24,7 @@ polarFreq(
   key.position = "right",
   key = TRUE,
   auto.text = TRUE,
+  plot = TRUE,
   ...
 )
 }
@@ -138,6 +139,10 @@ and \code{"left"}.}
 \code{TRUE} titles and axis labels will automatically try and format
 pollutant names and units properly e.g.  by subscripting the \sQuote{2}
 in NO2.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{\dots}{Other graphical parameters passed onto \code{lattice:xyplot}
 and \code{cutData}. For example, \code{polarFreq} passes the option

--- a/man/polarPlot.Rd
+++ b/man/polarPlot.Rd
@@ -37,6 +37,7 @@ polarPlot(
   y_error = NA,
   kernel = "gaussian",
   tau = 0.5,
+  plot = TRUE,
   ...
 )
 }
@@ -309,6 +310,10 @@ supported but this may be enhanced in the future.}
 \item{tau}{The quantile to be estimated when \code{statistic} is set to
 \code{"quantile.slope"}. Default is \code{0.5} which is equal to the median
 and will be ignored if \code{"quantile.slope"} is not used.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{Other graphical parameters passed onto \code{lattice:levelplot}
 and \code{cutData}. For example, \code{polarPlot} passes the option

--- a/man/scatterPlot.Rd
+++ b/man/scatterPlot.Rd
@@ -42,6 +42,7 @@ scatterPlot(
   dist = 0.02,
   map = FALSE,
   auto.text = TRUE,
+  plot = TRUE,
   ...
 )
 }
@@ -246,6 +247,10 @@ development.}
 \item{auto.text}{Either \code{TRUE} (default) or \code{FALSE}. If
 \code{TRUE} titles and axis labels will automatically try and format
 pollutant names and units properly e.g.  by subscripting the \sQuote{2} in NO2.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{Other graphical parameters are passed onto
 \code{cutData} and an appropriate \code{lattice} plot function

--- a/man/smoothTrend.Rd
+++ b/man/smoothTrend.Rd
@@ -29,6 +29,7 @@ smoothTrend(
   date.breaks = 7,
   auto.text = TRUE,
   k = NULL,
+  plot = TRUE,
   ...
 )
 }
@@ -152,6 +153,10 @@ NO2.}
 package \code{mgcv}. By default it is not used and the amount of smoothing
 is optimised automatically. However, sometimes it is useful to set the
 smoothing amount manually using \code{k}.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{Other graphical parameters are passed onto \code{cutData} and
 \code{lattice:xyplot}. For example, \code{smoothTrend} passes the option

--- a/man/summaryPlot.Rd
+++ b/man/summaryPlot.Rd
@@ -23,68 +23,63 @@ summaryPlot(
   cols = NULL,
   date.breaks = 7,
   auto.text = TRUE,
+  plot = TRUE,
+  debug = FALSE,
   ...
 )
 }
 \arguments{
-\item{mydata}{A data frame to be summarised. Must contain a
-\code{date} field and at least one other parameter.}
+\item{mydata}{A data frame to be summarised. Must contain a \code{date}
+field and at least one other parameter.}
 
-\item{na.len}{Missing data are only shown with at least
-\code{na.len} \emph{contiguous} missing vales. The purpose of
-setting \code{na.len} is for clarity: with long time series it
-is difficult to see where individual missing hours are.
-Furthermore, setting \code{na.len = 96}, for example would show
-where there are at least 4 days of continuous missing data.}
+\item{na.len}{Missing data are only shown with at least \code{na.len}
+\emph{contiguous} missing vales. The purpose of setting \code{na.len} is
+for clarity: with long time series it is difficult to see where individual
+missing hours are. Furthermore, setting \code{na.len = 96}, for example
+would show where there are at least 4 days of continuous missing data.}
 
-\item{clip}{When data contain outliers, the histogram or density
-plot can fail to show the distribution of the main body of data.
-Setting \code{clip = TRUE}, will remove the top 1 % of data to
-yield what is often a better display of the overall distribution
-of the data. The amount of clipping can be set with
-\code{percentile}.}
+\item{clip}{When data contain outliers, the histogram or density plot can
+fail to show the distribution of the main body of data. Setting \code{clip
+= TRUE}, will remove the top 1 % of data to yield what is often a better
+display of the overall distribution of the data. The amount of clipping
+can be set with \code{percentile}.}
 
 \item{percentile}{This is used to clip the data. For example,
-\code{percentile = 0.99} (the default) will remove the top 1
-percentile of values i.e. values greater than the 99th
-percentile will not be used.}
+\code{percentile = 0.99} (the default) will remove the top 1 percentile of
+values i.e. values greater than the 99th percentile will not be used.}
 
-\item{type}{\code{type} is used to determine whether a histogram
-(the default) or a density plot is used to show the distribution
-of the data.}
+\item{type}{\code{type} is used to determine whether a histogram (the
+default) or a density plot is used to show the distribution of the data.}
 
-\item{pollutant}{\code{pollutant} is used when there is a field
-\code{site} and there is more than one site in the data frame.}
+\item{pollutant}{\code{pollutant} is used when there is a field \code{site}
+and there is more than one site in the data frame.}
 
-\item{period}{\code{period} is either \code{years} (the default)
-or \code{months}. Statistics are calculated depending on the
-\code{period} chosen.}
+\item{period}{\code{period} is either \code{years} (the default) or
+\code{months}. Statistics are calculated depending on the \code{period}
+chosen.}
 
-\item{avg.time}{This defines the time period to average the time
-series plots. Can be \dQuote{sec}, \dQuote{min}, \dQuote{hour},
-\dQuote{day} (the default), \dQuote{week}, \dQuote{month},
-\dQuote{quarter} or \dQuote{year}. For much increased
-flexibility a number can precede these options followed by a
-space. For example, a timeAverage of 2 months would be
-\code{avg.time = "2 month"}.}
+\item{avg.time}{This defines the time period to average the time series
+plots. Can be \dQuote{sec}, \dQuote{min}, \dQuote{hour}, \dQuote{day} (the
+default), \dQuote{week}, \dQuote{month}, \dQuote{quarter} or
+\dQuote{year}. For much increased flexibility a number can precede these
+options followed by a space. For example, a timeAverage of 2 months would
+be \code{avg.time = "2 month"}.}
 
 \item{print.datacap}{Should the data capture \% be shown for each period?}
 
-\item{breaks}{Number of histogram bins. Sometime useful but not
-easy to set a single value for a range of very different
-variables.}
+\item{breaks}{Number of histogram bins. Sometime useful but not easy to set
+a single value for a range of very different variables.}
 
 \item{plot.type}{The \code{lattice} plot type, which is a line
 (\code{plot.type = "l"}) by default. Another useful option is
 \code{plot.type = "h"}, which draws vertical lines.}
 
-\item{col.trend}{Colour to be used to show the monthly trend of
-the data, shown as a shaded region. Type \code{colors()} into R
-to see the full range of colour names.}
+\item{col.trend}{Colour to be used to show the monthly trend of the data,
+shown as a shaded region. Type \code{colors()} into R to see the full
+range of colour names.}
 
-\item{col.data}{Colour to be used to show the \emph{presence} of
-data. Type \code{colors()} into R to see the full range of
-colour names.}
+\item{col.data}{Colour to be used to show the \emph{presence} of data. Type
+\code{colors()} into R to see the full range of colour names.}
 
 \item{col.mis}{Colour to be used to show missing data.}
 
@@ -93,74 +88,73 @@ colour names.}
 \item{cols}{Predefined colour scheme, currently only enabled for
 \code{"greyscale"}.}
 
-\item{date.breaks}{Number of major x-axis intervals to use. The
-function will try and choose a sensible number of dates/times as
-well as formatting the date/time appropriately to the range
-being considered.  This does not always work as desired
-automatically. The user can therefore increase or decrease the
-number of intervals by adjusting the value of \code{date.breaks}
-up or down.}
+\item{date.breaks}{Number of major x-axis intervals to use. The function
+will try and choose a sensible number of dates/times as well as formatting
+the date/time appropriately to the range being considered.  This does not
+always work as desired automatically. The user can therefore increase or
+decrease the number of intervals by adjusting the value of
+\code{date.breaks} up or down.}
 
 \item{auto.text}{Either \code{TRUE} (default) or \code{FALSE}. If
-\code{TRUE} titles and axis labels will automatically try and
-format pollutant names and units properly e.g.  by subscripting
-the \sQuote{2} in NO2.}
+\code{TRUE} titles and axis labels will automatically try and format
+pollutant names and units properly e.g.  by subscripting the \sQuote{2} in
+NO2.}
 
-\item{...}{Other graphical parameters. Commonly used examples
-include the axis and title labelling options (such as
-\code{xlab}, \code{ylab} and \code{main}), which are all passed
-to the plot via \code{quickText} to handle routine formatting.
-As \code{summaryPlot} has two components, the axis labels may be
-a vector. For example, the default case (\code{type =
-"histogram"}) sets y labels equivalent to \code{ylab = c("",
-"Percent of Total")}.}
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other ways.}
+
+\item{debug}{Should data types be printed to the console? \code{TRUE} can be
+useful for debugging.}
+
+\item{...}{Other graphical parameters. Commonly used examples include the
+axis and title labelling options (such as \code{xlab}, \code{ylab} and
+\code{main}), which are all passed to the plot via \code{quickText} to
+handle routine formatting. As \code{summaryPlot} has two components, the
+axis labels may be a vector. For example, the default case (\code{type =
+"histogram"}) sets y labels equivalent to \code{ylab = c("", "Percent of
+Total")}.}
 }
 \description{
-This function provides a quick graphical and numerical summary of
-data. The location presence/absence of data are shown, with
-summary statistics and plots of variable distributions.
-\code{summaryPlot} can also provide summaries of a single
-pollutant across many sites.
+This function provides a quick graphical and numerical summary of data. The
+location presence/absence of data are shown, with summary statistics and
+plots of variable distributions. \code{summaryPlot} can also provide
+summaries of a single pollutant across many sites.
 }
 \details{
 \code{summaryPlot} produces two panels of plots: one showing the
-presence/absence of data and the other the distributions. The left
-panel shows time series and codes the presence or absence of data
-in different colours. By stacking the plots one on top of another
-it is easy to compare different pollutants/variables. Overall
-statistics are given for each variable: mean, maximum, minimum,
-missing hours (also expressed as a percentage), median and the
-95th percentile. For each year the data capture rate (expressed as
-a percentage of hours in that year) is also given.
+presence/absence of data and the other the distributions. The left panel
+shows time series and codes the presence or absence of data in different
+colours. By stacking the plots one on top of another it is easy to compare
+different pollutants/variables. Overall statistics are given for each
+variable: mean, maximum, minimum, missing hours (also expressed as a
+percentage), median and the 95th percentile. For each year the data capture
+rate (expressed as a percentage of hours in that year) is also given.
 
-The right panel shows either a histogram or a density plot
-depending on the choice of \code{type}. Density plots avoid the
-issue of arbitrary bin sizes that can sometimes provide a
-misleading view of the data distribution.  Density plots are often
-more appropriate, but their effectiveness will depend on the data
-in question.
+The right panel shows either a histogram or a density plot depending on the
+choice of \code{type}. Density plots avoid the issue of arbitrary bin sizes
+that can sometimes provide a misleading view of the data distribution.
+Density plots are often more appropriate, but their effectiveness will
+depend on the data in question.
 
-\code{summaryPlot} will only show data that are numeric or integer
-type.  This is useful for checking that data have been imported
-properly. For example, if for some reason a column representing
-wind speed erroneosly had one or more fields with charcters in,
-the whole column would be either character or factor type. The
-absence of a wind speed variable in the \code{summaryPlot} plot
-would therefore indicate a problem with the input data. In this
-particular case, the user should go back to the source data and
-remove the characters or remove them using R functions.
+\code{summaryPlot} will only show data that are numeric or integer type.
+This is useful for checking that data have been imported properly. For
+example, if for some reason a column representing wind speed erroneosly had
+one or more fields with charcters in, the whole column would be either
+character or factor type. The absence of a wind speed variable in the
+\code{summaryPlot} plot would therefore indicate a problem with the input
+data. In this particular case, the user should go back to the source data
+and remove the characters or remove them using R functions.
 
-If there is a field \code{site}, which would generally mean there
-is more than one site, \code{summaryPlot} will provide information
-on a \emph{single} pollutant across all sites, rather than provide
-details on all pollutants at a \emph{single} site. In this case
-the user should also provide a name of a pollutant e.g.
-\code{pollutant = "nox"}. If a pollutant is not provided the first
-numeric field will automatically be chosen.
+If there is a field \code{site}, which would generally mean there is more
+than one site, \code{summaryPlot} will provide information on a
+\emph{single} pollutant across all sites, rather than provide details on all
+pollutants at a \emph{single} site. In this case the user should also
+provide a name of a pollutant e.g. \code{pollutant = "nox"}. If a pollutant
+is not provided the first numeric field will automatically be chosen.
 
-\bold{It is strongly recommended that the \code{summaryPlot}
-function is applied to all new imported data sets to ensure the
-data are imported as expected.}
+\bold{It is strongly recommended that the \code{summaryPlot} function is
+applied to all new imported data sets to ensure the data are imported as
+expected.}
 }
 \examples{
 

--- a/man/timePlot.Rd
+++ b/man/timePlot.Rd
@@ -32,6 +32,7 @@ timePlot(
   date.breaks = 7,
   date.format = NULL,
   auto.text = TRUE,
+  plot = TRUE,
   ...
 )
 }
@@ -222,6 +223,10 @@ example, to format the date like \dQuote{Jan-2012} set
 \code{TRUE} titles and axis labels will automatically try and
 format pollutant names and units properly e.g.  by subscripting
 the \sQuote{2} in NO2.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{Other graphical parameters are passed onto
 \code{cutData} and \code{lattice:xyplot}. For example,

--- a/man/timeProp.Rd
+++ b/man/timeProp.Rd
@@ -18,6 +18,7 @@ timeProp(
   key.position = "right",
   key.title = proportion,
   auto.text = TRUE,
+  plot = TRUE,
   ...
 )
 }
@@ -106,6 +107,10 @@ Allowed arguments currently include \dQuote{top},
 \code{TRUE} titles and axis labels etc. will automatically try
 and format pollutant names and units properly e.g.  by
 subscripting the `2' in NO2.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{Other graphical parameters passed onto \code{timeProp}
 and \code{cutData}. For example, \code{timeProp} passes the

--- a/man/timeVariation.Rd
+++ b/man/timeVariation.Rd
@@ -26,6 +26,7 @@ timeVariation(
   auto.text = TRUE,
   alpha = 0.4,
   month.last = FALSE,
+  plot = TRUE,
   ...
 )
 }
@@ -158,6 +159,10 @@ NO2.}
 \item{month.last}{Should the order of the plots be changed so the plot 
 showing monthly means be the last plot for a logical hierarchy of 
 averaging periods?}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{Other graphical parameters passed onto \code{lattice:xyplot} and
 \code{cutData}. For example, in the case of \code{cutData} the option

--- a/man/trajCluster.Rd
+++ b/man/trajCluster.Rd
@@ -8,7 +8,6 @@ trajCluster(
   traj,
   method = "Euclid",
   n.cluster = 5,
-  plot = TRUE,
   type = "default",
   cols = "Set1",
   split.after = FALSE,
@@ -20,6 +19,7 @@ trajCluster(
   orientation = c(90, 0, 0),
   by.type = FALSE,
   origin = TRUE,
+  plot = TRUE,
   ...
 )
 }
@@ -32,8 +32,6 @@ back trajectories. There are two methods available:
 \dQuote{Euclid} and \dQuote{Angle}.}
 
 \item{n.cluster}{Number of clusters to calculate.}
-
-\item{plot}{Should a plot be produced?}
 
 \item{type}{\code{type} determines how the data are split i.e.
 conditioned, and then plotted. The default is will produce a
@@ -98,6 +96,10 @@ will make each panel add up to 100.}
 
 \item{origin}{If \code{TRUE} a filled circle dot is shown to mark the
 receptor point.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{Other graphical parameters passed onto
 \code{lattice:levelplot} and \code{cutData}. Similarly, common

--- a/man/trajLevel.Rd
+++ b/man/trajLevel.Rd
@@ -28,6 +28,7 @@ trajLevel(
   orientation = c(90, 0, 0),
   grid.col = "deepskyblue",
   origin = TRUE,
+  plot = TRUE,
   ...
 )
 }
@@ -160,6 +161,10 @@ of the longitude coordinates in the map.}
 set \code{grid.col = "transparent"}.}
 
 \item{origin}{should the receptor origin be shown by a black dot?}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{other arguments are passed to \code{cutData} and
 \code{scatterPlot}. This provides access to arguments used in both these

--- a/man/trendLevel.Rd
+++ b/man/trendLevel.Rd
@@ -26,6 +26,7 @@ trendLevel(
   stat.safe.mode = TRUE,
   drop.unused.types = TRUE,
   col.na = "white",
+  plot = TRUE,
   ...
 )
 }
@@ -140,6 +141,10 @@ default, \code{TRUE}, excludes these empty panels from the plot. The
 alternative \code{FALSE} plots all \code{type} panels.}
 
 \item{col.na}{Colour to be used to show missing data.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{Addition options are passed on to \code{cutData} for
 \code{type} handling and \code{levelplot} in \code{lattice} for finer

--- a/man/windRose.Rd
+++ b/man/windRose.Rd
@@ -5,20 +5,40 @@
 \alias{pollutionRose}
 \title{Traditional wind rose plot and pollution rose variation}
 \usage{
-windRose(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
-  ws.int = 2, angle = 30, type = "default", bias.corr = TRUE, cols
-  = "default", grid.line = NULL, width = 1, seg = NULL, auto.text
-  = TRUE, breaks = 4, offset = 10, normalise = FALSE, max.freq =
-  NULL, paddle = TRUE, key.header = NULL, key.footer = "(m/s)",
-  key.position = "bottom", key = TRUE, dig.lab = 5, include.lowest = FALSE,
-  statistic =
-  "prop.count", pollutant = NULL, annotate = TRUE, angle.scale =
-  315, border = NA, ...)
-
-
-  pollutionRose(mydata, pollutant = "nox", key.footer = pollutant,
-  key.position = "right", key = TRUE, breaks = 6, paddle = FALSE,
-  seg = 0.9, normalise = FALSE, ...)
+windRose(
+  mydata,
+  ws = "ws",
+  wd = "wd",
+  ws2 = NA,
+  wd2 = NA,
+  ws.int = 2,
+  angle = 30,
+  type = "default",
+  bias.corr = TRUE,
+  cols = "default",
+  grid.line = NULL,
+  width = 1,
+  seg = NULL,
+  auto.text = TRUE,
+  breaks = 4,
+  offset = 10,
+  normalise = FALSE,
+  max.freq = NULL,
+  paddle = TRUE,
+  key.header = NULL,
+  key.footer = "(m/s)",
+  key.position = "bottom",
+  key = TRUE,
+  dig.lab = 5,
+  include.lowest = FALSE,
+  statistic = "prop.count",
+  pollutant = NULL,
+  annotate = TRUE,
+  angle.scale = 315,
+  border = NA,
+  plot = TRUE,
+  ...
+)
 }
 \arguments{
 \item{mydata}{A data frame containing fields \code{ws} and
@@ -183,6 +203,10 @@ direction.}
 
 \item{border}{Border colour for shaded areas. Default is no
 border.}
+
+\item{plot}{Should a plot be produced? \code{FALSE} can be useful when
+analysing data to extract plot components and plotting them in other
+ways.}
 
 \item{...}{For \code{pollutionRose} other parameters that are
 passed on to \code{windRose}. For \code{windRose} other


### PR DESCRIPTION
Added the "plot" option already present in `trajCluster()` to all openair plotting functions. `plot = TRUE` is the default, which is the current `{openair}` behaviour. `plot = FALSE` deactivates all "side-effects" in `{openair}` functions (printing and plotting) meaning all that the functions do is invisibly return their openair object.

This is useful for replotting, especially in Markdown / Quarto documents and in other packages.

Also:
- Made `trajLevel()` return its plot (currently does not)
- Added `debug` to `summaryPlot()`, which turns on/off the printing of data types.
- Remove `@usage` from `windRose()` (caused R CMD issues, and is auto-generated now)