### PR TITLE
Add "turbo" to openColours()

### DIFF
--- a/R/openColours.R
+++ b/R/openColours.R
@@ -8,9 +8,9 @@
 ##'
 ##' Each of the pre-defined schemes have merits and their use will depend on a
 ##' particular situation. For showing incrementing concentrations e.g. high
-##' concentrations emphasised, then "default", "heat", "jet" and "increment" are
-##' very useful. See also the description of \code{RColorBrewer} schemes for the
-##' option \code{scheme}.
+##' concentrations emphasised, then "default", "heat", "jet", "turbo", and
+##' "increment" are very useful. See also the description of \code{RColorBrewer}
+##' schemes for the option \code{scheme}.
 ##'
 ##' To colour-code categorical-type problems e.g. colours for different
 ##' pollutants, "hue" and "brewer1" are useful.
@@ -24,12 +24,12 @@
 ##' To see the full list of names, type \code{colors()} into R.
 ##'
 ##' @param scheme The pre-defined schemes are "increment", "default", "brewer1",
-##'   "heat", "jet", "hue", "greyscale", or a vector of R colour names e.g.
-##'   c("green", "blue"). It is also possible to supply colour schemes from the
-##'   \code{RColorBrewer} package. This package defines three types of colour
-##'   schemes: sequential, diverging or qualitative. See
-##'   \url{https://colorbrewer2.org/} for more details concerning the orginal work
-##'   on which this is based.
+##'   "heat", "jet", "turbo", "hue", "greyscale", or a vector of R colour names
+##'   e.g. c("green", "blue"). It is also possible to supply colour schemes from
+##'   the \code{RColorBrewer} package. This package defines three types of
+##'   colour schemes: sequential, diverging or qualitative. See
+##'   \url{https://colorbrewer2.org/} for more details concerning the orginal
+##'   work on which this is based.
 ##'
 ##'   Simplified versions of the \code{viridis} colours are also available.
 ##'   These include "viridis", "plasma", "magma", "inferno" and "cividis".
@@ -74,7 +74,7 @@
 ##' cols <- openColours(c("yellow", "green", "red"), 10)
 ##' cols
 ##'
-##' 
+##'
 openColours <- function(scheme = "default", n = 100) {
 
   ## pre-defined brewer colour palletes sequential, diverging, qualitative
@@ -89,48 +89,51 @@ openColours <- function(scheme = "default", n = 100) {
   brewer.n <- c(rep(9, 18), rep(9, 9), c(8, 8, 12, 9, 8, 9, 8, 12))
 
   ## predefined schemes
-  schemes <- c("increment", "default", "brewer1", "heat", "jet", "hue", 
+  schemes <- c("increment", "default", "brewer1", "heat", "jet", "hue",
                "greyscale", brewer.col, "cbPalette", "viridis", "magma",
-               "inferno", "plasma", "cividis")
+               "inferno", "plasma", "cividis", "turbo")
 
 
   ## schemes
   heat <- colorRampPalette(brewer.pal(9, "YlOrRd"), interpolate = "spline")
 
   viridis <- colorRampPalette(c(
-    "#440154FF", "#482878FF", "#3E4A89FF", "#31688EFF", "#26828EFF", "#1F9E89FF", 
+    "#440154FF", "#482878FF", "#3E4A89FF", "#31688EFF", "#26828EFF", "#1F9E89FF",
     "#35B779FF", "#6DCD59FF", "#B4DE2CFF", "#FDE725FF"
   ))
-  
+
   inferno <- colorRampPalette(c(
     "#000004FF", "#1B0C42FF", "#4B0C6BFF", "#781C6DFF", "#A52C60FF", "#CF4446FF",
     "#ED6925FF", "#FB9A06FF", "#F7D03CFF", "#FCFFA4FF"
   ))
-  
+
   magma <- colorRampPalette(c(
     "#000004FF", "#180F3EFF", "#451077FF", "#721F81FF", "#9F2F7FFF", "#CD4071FF",
     "#F1605DFF", "#FD9567FF", "#FEC98DFF", "#FCFDBFFF"
   ))
-  
+
   plasma <- colorRampPalette(c(
     "#0D0887FF", "#47039FFF", "#7301A8FF", "#9C179EFF", "#BD3786FF", "#D8576BFF",
     "#ED7953FF", "#FA9E3BFF", "#FDC926FF", "#F0F921FF"
   ))
-  
+
   cividis <- colorRampPalette(c(
     "#00204DFF", "#00336FFF", "#39486BFF", "#575C6DFF", "#707173FF", "#8A8779FF",
     "#A69D75FF", "#C4B56CFF", "#E4CF5BFF", "#FFEA46FF"
   ))
-  
-  
+
+
   jet <- colorRampPalette(c(
     "#00007F", "blue", "#007FFF", "cyan",
     "#7FFF7F", "yellow", "#FF7F00", "red", "#7F0000"
   ))
 
+  turbo <- colorRampPalette(c(
+    '#30123BFF', '#4662D7FF', '#36AAF9FF', '#1AE4B6FF', '#72FE5EFF',
+    '#C7EF34FF', '#FABA39FF', '#F66B19FF', '#CB2A04FF', '#7A0403FF'
+  ))
+
   default.col <- colorRampPalette(brewer.pal(11, "Spectral"), interpolate = "spline")
-
-
 
   ## for this pallete use specfified number if possible - because it has been thought about...
   brewer1 <- function(n) {
@@ -178,22 +181,22 @@ openColours <- function(scheme = "default", n = 100) {
 
   # The palette with grey:
   cbPalette <- function(n) {
-    
-    cols <- c("#999999", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", 
+
+    cols <- c("#999999", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2",
               "#D55E00", "#CC79A7")
-    
+
     if (n >= 1 && n < 9) {
-      
-      cols <- cols[1:n] 
-      
+
+      cols <- cols[1:n]
+
     } else {
-    
+
       warning("Too many colours selected. Should be 1 to 8.")
     }
   }
-    
-  
-  
+
+
+
   ## error catcher
   if (length(scheme) == 1) {
     if (scheme %in% brewer.col) cols <- find.brewer(scheme, n)
@@ -203,6 +206,7 @@ openColours <- function(scheme = "default", n = 100) {
     if (scheme %in% brewer.col) cols <- find.brewer(scheme, n)
     if (scheme == "heat") cols <- heat(n)
     if (scheme == "jet") cols <- jet(n)
+    if (scheme == "turbo") cols <- turbo(n)
     if (scheme == "viridis") cols <- viridis(n)
     if (scheme == "magma") cols <- magma(n)
     if (scheme == "inferno") cols <- inferno(n)

--- a/R/polarFreq.R
+++ b/R/polarFreq.R
@@ -7,24 +7,24 @@
 ##'
 ##' \code{polarFreq} is its default use provides details of wind speed and
 ##' direction frequencies. In this respect it is similar to
-##' \code{\link{windRose}}, but considers wind direction intervals of 10
-##' degrees and a user-specified wind speed interval. The frequency of wind
+##' \code{\link{windRose}}, but considers wind direction intervals of 10 degrees
+##' and a user-specified wind speed interval. The frequency of wind
 ##' speeds/directions formed by these \sQuote{bins} is represented on a colour
 ##' scale.
 ##'
 ##' The \code{polarFreq} function is more flexible than either
-##' \code{\link{windRose}} or \code{\link{polarPlot}}. It can, for example,
-##' also consider pollutant concentrations (see examples below). Instead of the
+##' \code{\link{windRose}} or \code{\link{polarPlot}}. It can, for example, also
+##' consider pollutant concentrations (see examples below). Instead of the
 ##' number of data points in each bin, the concentration can be shown. Further,
 ##' a range of statistics can be used to describe each bin - see
 ##' \code{statistic} above. Plotting mean concentrations is useful for source
 ##' identification and is the same as \code{\link{polarPlot}} but without
 ##' smoothing, which may be preferable for some data. Plotting with
 ##' \code{statistic = "weighted.mean"} is particularly useful for understanding
-##' the relative importance of different source contributions. For example,
-##' high mean concentrations may be observed for high wind speed conditions,
-##' but the weighted mean concentration may well show that the contribution to
-##' overall concentrations is very low.
+##' the relative importance of different source contributions. For example, high
+##' mean concentrations may be observed for high wind speed conditions, but the
+##' weighted mean concentration may well show that the contribution to overall
+##' concentrations is very low.
 ##'
 ##' \code{polarFreq} also offers great flexibility with the scale used and the
 ##' user has fine control over both the range, interval and colour.
@@ -34,77 +34,74 @@
 ##' @param pollutant Mandatory. A pollutant name corresponding to a variable in
 ##'   a data frame should be supplied e.g. \code{pollutant = "nox"}
 ##' @param statistic The statistic that should be applied to each wind
-##' speed/direction bin. Can be \dQuote{frequency}, \dQuote{mean},
-##' \dQuote{median}, \dQuote{max} (maximum), \dQuote{stdev} (standard
-##' deviation) or \dQuote{weighted.mean}. The option
-##' \dQuote{frequency} (the default) is the simplest and plots the
-##' frequency of wind speed/direction in different bins. The scale
-##' therefore shows the counts in each bin. The option \dQuote{mean}
-##' will plot the mean concentration of a pollutant (see next point)
-##' in wind speed/direction bins, and so on.  Finally,
-##' \dQuote{weighted.mean} will plot the concentration of a pollutant
-##' weighted by wind speed/direction. Each segment therefore provides
-##' the percentage overall contribution to the total concentration.
-##' More information is given in the examples. Note that for options
-##' other than \dQuote{frequency}, it is necessary to also provide the
-##' name of a pollutant. See function \code{cutData} for further
-##' details.
+##'   speed/direction bin. Can be \dQuote{frequency}, \dQuote{mean},
+##'   \dQuote{median}, \dQuote{max} (maximum), \dQuote{stdev} (standard
+##'   deviation) or \dQuote{weighted.mean}. The option \dQuote{frequency} (the
+##'   default) is the simplest and plots the frequency of wind speed/direction
+##'   in different bins. The scale therefore shows the counts in each bin. The
+##'   option \dQuote{mean} will plot the mean concentration of a pollutant (see
+##'   next point) in wind speed/direction bins, and so on.  Finally,
+##'   \dQuote{weighted.mean} will plot the concentration of a pollutant weighted
+##'   by wind speed/direction. Each segment therefore provides the percentage
+##'   overall contribution to the total concentration. More information is given
+##'   in the examples. Note that for options other than \dQuote{frequency}, it
+##'   is necessary to also provide the name of a pollutant. See function
+##'   \code{cutData} for further details.
 ##' @param ws.int Wind speed interval assumed. In some cases e.g. a low met
 ##'   mast, an interval of 0.5 may be more appropriate.
 ##' @param wd.nint Number of intervals of wind direction.
 ##' @param grid.line Radial spacing of grid lines.
 ##' @param breaks The user can provide their own scale. \code{breaks} expects a
-##'   sequence of numbers that define the range of the scale. The sequence
-##'   could represent one with equal spacing e.g. \code{breaks = seq(0, 100,
-##'   10)} - a scale from 0-10 in intervals of 10, or a more flexible sequence
-##'   e.g. \code{breaks = c(0, 1, 5, 7, 10)}, which may be useful for some
+##'   sequence of numbers that define the range of the scale. The sequence could
+##'   represent one with equal spacing e.g. \code{breaks = seq(0, 100, 10)} - a
+##'   scale from 0-10 in intervals of 10, or a more flexible sequence e.g.
+##'   \code{breaks = c(0, 1, 5, 7, 10)}, which may be useful for some
 ##'   situations.
 ##' @param cols Colours to be used for plotting. Options include
-##' \dQuote{default}, \dQuote{increment}, \dQuote{heat}, \dQuote{jet}
-##' and \code{RColorBrewer} colours --- see the \code{openair}
-##' \code{openColours} function for more details. For user defined the
-##' user can supply a list of colour names recognised by R (type
-##' \code{colours()} to see the full list). An example would be
-##' \code{cols = c("yellow", "green", "blue")}
+##'   \dQuote{default}, \dQuote{increment}, \dQuote{heat}, \dQuote{jet},
+##'   \dQuote{turbo}, and \code{RColorBrewer} colours --- see the \code{openair}
+##'   \code{openColours} function for more details. For user defined the user
+##'   can supply a list of colour names recognised by R (type \code{colours()}
+##'   to see the full list). An example would be \code{cols = c("yellow",
+##'   "green", "blue")}
 ##' @param trans Should a transformation be applied? Sometimes when producing
-##'   plots of this kind they can be dominated by a few high points. The
-##'   default therefore is \code{TRUE} and a square-root transform is applied.
-##'   This results in a non-linear scale and (usually) a better representation
-##'   of the distribution. If set to \code{FALSE} a linear scale is used.
-##' @param type \code{type} determines how the data are split
-##' i.e. conditioned, and then plotted. The default is will produce a
-##' single plot using the entire data. Type can be one of the built-in
-##' types as detailed in \code{cutData} e.g. \dQuote{season},
-##' \dQuote{year}, \dQuote{weekday} and so on. For example, \code{type
-##' = "season"} will produce four plots --- one for each season.
+##'   plots of this kind they can be dominated by a few high points. The default
+##'   therefore is \code{TRUE} and a square-root transform is applied. This
+##'   results in a non-linear scale and (usually) a better representation of the
+##'   distribution. If set to \code{FALSE} a linear scale is used.
+##' @param type \code{type} determines how the data are split i.e. conditioned,
+##'   and then plotted. The default is will produce a single plot using the
+##'   entire data. Type can be one of the built-in types as detailed in
+##'   \code{cutData} e.g. \dQuote{season}, \dQuote{year}, \dQuote{weekday} and
+##'   so on. For example, \code{type = "season"} will produce four plots --- one
+##'   for each season.
 ##'
-##' It is also possible to choose \code{type} as another variable in
-##' the data frame. If that variable is numeric, then the data will be
-##' split into four quantiles (if possible) and labelled
-##' accordingly. If type is an existing character or factor variable,
-##' then those categories/levels will be used directly. This offers
-##' great flexibility for understanding the variation of different
-##' variables and how they depend on one another.
+##'   It is also possible to choose \code{type} as another variable in the data
+##'   frame. If that variable is numeric, then the data will be split into four
+##'   quantiles (if possible) and labelled accordingly. If type is an existing
+##'   character or factor variable, then those categories/levels will be used
+##'   directly. This offers great flexibility for understanding the variation of
+##'   different variables and how they depend on one another.
 ##'
-##' Type can be up length two e.g. \code{type = c("season", "weekday")} will
+##'   Type can be up length two e.g. \code{type = c("season", "weekday")} will
 ##'   produce a 2x2 plot split by season and day of the week. Note, when two
 ##'   types are provided the first forms the columns and the second the rows.
 ##' @param min.bin The minimum number of points allowed in a wind speed/wind
-##'   direction bin.  The default is 1. A value of two requires at least 2
-##'   valid records in each bin an so on; bins with less than 2 valid records
-##'   are set to NA. Care should be taken when using a value > 1 because of the
-##'   risk of removing real data points. It is recommended to consider your
-##'   data with care. Also, the \code{polarPlot} function can be of use in such
+##'   direction bin.  The default is 1. A value of two requires at least 2 valid
+##'   records in each bin an so on; bins with less than 2 valid records are set
+##'   to NA. Care should be taken when using a value > 1 because of the risk of
+##'   removing real data points. It is recommended to consider your data with
+##'   care. Also, the \code{polarPlot} function can be of use in such
 ##'   circumstances.
 ##' @param ws.upper A user-defined upper wind speed to use. This is useful for
 ##'   ensuring a consistent scale between different plots. For example, to
 ##'   always ensure that wind speeds are displayed between 1-10, set
 ##'   \code{ws.int = 10}.
-##' @param offset \code{offset} controls the size of the \sQuote{hole}
-##' in the middle and is expressed as a percentage of the maximum wind
-##' speed. Setting a higher \code{offset} e.g. 50 is useful for
-##' \code{statistic = "weighted.mean"} when \code{ws.int} is greater
-##' than the maximum wind speed. See example below.
+##' @param offset \code{offset} controls the size of the \sQuote{hole} in the
+##'   middle and is expressed as a percentage of the maximum wind speed. Setting
+##'   a higher \code{offset} e.g. 50 is useful for \code{statistic =
+##'   "weighted.mean"} when \code{ws.int} is greater than the maximum wind
+##'   speed. See example below.
 ##' @param border.col The colour of the boundary of each wind speed/direction
 ##'   bin. The default is transparent. Another useful choice sometimes is
 ##'   "white".
@@ -120,21 +117,20 @@
 ##'   \code{drawOpenKey} for further details.
 ##' @param auto.text Either \code{TRUE} (default) or \code{FALSE}. If
 ##'   \code{TRUE} titles and axis labels will automatically try and format
-##'   pollutant names and units properly e.g.  by subscripting the \sQuote{2}
-##'   in NO2.
+##'   pollutant names and units properly e.g.  by subscripting the \sQuote{2} in
+##'   NO2.
 ##' @param plot Should a plot be produced? \code{FALSE} can be useful when
-##'   analysing data to extract plot components and plotting them in other
-##'   ways.
+##'   analysing data to extract plot components and plotting them in other ways.
 ##' @param \dots Other graphical parameters passed onto \code{lattice:xyplot}
 ##'   and \code{cutData}. For example, \code{polarFreq} passes the option
 ##'   \code{hemisphere = "southern"} on to \code{cutData} to provide southern
-##'   (rather than default northern) hemisphere handling of \code{type = "season"}.
-##'   Similarly, common axis and title labelling options (such as \code{xlab},
-##'   \code{ylab}, \code{main}) are passed to \code{xyplot} via \code{quickText}
-##'   to handle routine formatting.
+##'   (rather than default northern) hemisphere handling of \code{type =
+##'   "season"}. Similarly, common axis and title labelling options (such as
+##'   \code{xlab}, \code{ylab}, \code{main}) are passed to \code{xyplot} via
+##'   \code{quickText} to handle routine formatting.
 ##' @export
-##' @return As well as generating the plot itself, \code{polarFreq} also
-##'   returns an object of class \dQuote{openair}. The object includes three main
+##' @return As well as generating the plot itself, \code{polarFreq} also returns
+##'   an object of class \dQuote{openair}. The object includes three main
 ##'   components: \code{call}, the command used to generate the plot;
 ##'   \code{data}, the data frame of summarised information used to make the
 ##'   plot; and \code{plot}, the plot itself. If retained, e.g. using
@@ -142,7 +138,7 @@
 ##'   recover the data, reproduce or rework the original plot or undertake
 ##'   further analysis.
 ##'
-##' An openair output can be manipulated using a number of generic operations,
+##'   An openair output can be manipulated using a number of generic operations,
 ##'   including \code{print}, \code{plot} and \code{summary}.
 ##' @author David Carslaw
 ##' @seealso See Also as \code{\link{windRose}}, \code{\link{polarPlot}}
@@ -167,7 +163,7 @@
 ##'
 ##' #windRose for just 2000 and 2003 with different colours
 ##' \dontrun{polarFreq(subset(mydata, format(date, "%Y") %in% c(2000, 2003)),
-##' type = "year", cols = "jet")}
+##' type = "year", cols = "turbo")}
 ##'
 ##' # user defined breaks from 0-700 in intervals of 100 (note linear scale)
 ##' \dontrun{polarFreq(mydata, breaks = seq(0, 700, 100))}
@@ -198,34 +194,34 @@ polarFreq <- function(mydata,
                       key.footer = pollutant,
                       key.position = "right",
                       key = TRUE,
-                      auto.text = TRUE, 
+                      auto.text = TRUE,
                       plot = TRUE,
                       ...) {
-  
+
   ## extract necessary data
   vars <- c("wd", "ws")
   if (any(type %in% dateTypes)) vars <- c(vars, "date")
-  
+
   ## intervals in wind direction
   wd.int <- 360/round(wd.nint)
-  
+
   ## greyscale handling
   if (length(cols) == 1 && cols == "greyscale") {
     trellis.par.set(list(strip.background = list(col = "white")))
   }
-  
+
   ## set graphics
   current.strip <- trellis.par.get("strip.background")
   current.font <- trellis.par.get("fontsize")
-  
+
   ## reset graphic parameters
   on.exit(trellis.par.set(
     fontsize = current.font
   ))
-  
+
   ## extra.args setup
   extra.args <- list(...)
-  
+
   # label controls
   extra.args$xlab <- if ("xlab" %in% names(extra.args)) {
     quickText(extra.args$xlab, auto.text)
@@ -242,121 +238,121 @@ polarFreq <- function(mydata,
   } else {
     quickText("", auto.text)
   }
-  
+
   if ("fontsize" %in% names(extra.args)) {
     trellis.par.set(fontsize = list(text = extra.args$fontsize))
   }
-  
+
   if (!missing(pollutant)) vars <- c(vars, pollutant)
-  
+
   ## data checks
   mydata <- checkPrep(mydata, vars, type, remove.calm = FALSE)
-  
+
   ## to make first interval easier to work with, set ws = 0 + e
   ids <- which(mydata$ws == 0)
   mydata$ws[ids] <- mydata$ws[ids] + 0.0001
-  
+
   ## remove all NAs
   mydata <- na.omit(mydata)
-  
+
   mydata <- cutData(mydata, type, ...)
-  
+
   ## if pollutant chosen but no statistic - use mean, issue warning
   if (!missing(pollutant) & missing(statistic)) {
     statistic <- "mean"
     warning("No statistic chosen, using mean")
   }
-  
+
   ## if statistic chosen but no pollutant stop
   if (!missing(statistic) & missing(pollutant)) {
     stop("No pollutant chosen, please choose one e.g. pollutant = 'nox'")
   }
-  
+
   if (!missing(breaks)) trans <- FALSE ## over-ride transform if breaks supplied
-  
+
   if (missing(key.header)) key.header <- statistic
   if (key.header == "weighted.mean") key.header <- c("contribution", "(%)")
-  
+
   ## apply square root transform?
   if (trans) coef <- 2 else coef <- 1
-  
+
   ## set the upper wind speed
   if (is.na(ws.upper)) {
     max.ws <- max(mydata$ws, na.rm = TRUE)
   } else {
     max.ws <- ws.upper
   }
-  
+
   ## offset for "hollow" middle
   offset <- (max.ws * offset) / 5 / 10
-  
+
   ## make sure wd data are rounded to nearest 10
   mydata$wd <- wd.int * ceiling(mydata$wd / wd.int - 0.5)
-  
+
   prepare.grid <- function(mydata) {
     wd <- factor(mydata$wd)
     ws <- factor(ws.int * ceiling(mydata$ws / ws.int))
-    
+
     if (statistic == "frequency") ## case with only ws and wd
     {
       weights <- tapply(mydata$ws, list(wd, ws), function(x) length(na.omit(x)))
     }
-    
+
     if (statistic == "mean") {
       weights <- tapply(
         mydata[[pollutant]],
         list(wd, ws), function(x) mean(x, na.rm = TRUE)
       )
     }
-    
+
     if (statistic == "median") {
       weights <- tapply(
         mydata[[pollutant]],
         list(wd, ws), function(x) median(x, na.rm = TRUE)
       )
     }
-    
+
     if (statistic == "max") {
       weights <- tapply(
         mydata[[pollutant]],
         list(wd, ws), function(x) max(x, na.rm = TRUE)
       )
     }
-    
+
     if (statistic == "stdev") {
       weights <- tapply(
         mydata[[pollutant]],
         list(wd, ws), function(x) sd(x, na.rm = TRUE)
       )
     }
-    
+
     if (statistic == "weighted.mean") {
       weights <- tapply(
         mydata[[pollutant]], list(wd, ws),
         function(x) (mean(x) * length(x) / nrow(mydata))
       )
-      
+
       ## note sum for matrix
       weights <- 100 * weights / sum(sum(weights, na.rm = TRUE))
     }
-    
+
     weights <- as.vector(t(weights))
-    
+
     ## frequency - remove points with freq < min.bin
     bin.len <- tapply(mydata$ws, list(wd, ws), function(x) length(na.omit(x)))
     binned.len <- as.vector(t(bin.len))
     ids <- which(binned.len < min.bin)
     weights[ids] <- NA
-    
+
     ws.wd <- expand.grid(ws = as.numeric(levels(ws)), wd = as.numeric(levels(wd)))
-    
+
     weights <- cbind(ws.wd, weights)
     weights
   }
-  
-  
+
+
   poly <- function(dir, speed, colour) {
-    
+
     ## offset by 3 * ws.int so that centre is not compressed
     angle <- seq(dir - wd.int/2, dir + wd.int/2, length = round(wd.int))
     x1 <- (speed + offset - ws.int) * sin(pi * angle / 180)
@@ -365,22 +361,22 @@ polarFreq <- function(mydata,
     y2 <- rev((speed + offset) * cos(pi * angle / 180))
     lpolygon(c(x1, x2), c(y1, y2), col = colour, border = border.col, lwd = 0.5)
   }
-  
-  
-  results.grid <- mydata %>% 
+
+
+  results.grid <- mydata %>%
     group_by(across(type)) %>%
     do(prepare.grid(.))
-  
+
   results.grid <- na.omit(results.grid)
-  
+
   ## proper names of labelling ###################################################
   strip.dat <- strip.fun(results.grid, type, auto.text)
   strip <- strip.dat[[1]]
   strip.left <- strip.dat[[2]]
   pol.name <- strip.dat[[3]]
-  
+
   results.grid$weights <- results.grid$weights ^ (1 / coef)
-  
+
   nlev <- 200
   ## handle missing breaks arguments
   if (missing(breaks)) {
@@ -389,18 +385,18 @@ polarFreq <- function(mydata,
   } else {
     br <- breaks
   }
-  
+
   nlev2 <- length(breaks)
-  
+
   col <- openColours(cols, (nlev2 - 1))
-  
+
   results.grid$div <- cut(results.grid$weights, breaks, include.lowest = TRUE)
-  
+
   ## for pollution data
   results.grid$weights[results.grid$weights == "NaN"] <- 0
   results.grid$weights[which(is.na(results.grid$weights))] <- 0
-  
-  
+
+
   ##  scale key setup ################################################################################################
   legend <- list(
     col = col[1:(length(breaks) - 1)], at = breaks,
@@ -410,12 +406,12 @@ polarFreq <- function(mydata,
     height = 1, width = 1.5, fit = "all"
   )
   legend <- makeOpenKeyLegend(key, legend, "polarFreq")
-  
+
   temp <- paste(type, collapse = "+")
   myform <- formula(paste("ws ~ wd | ", temp, sep = ""))
-  
+
   span <- ws.int * floor(max.ws / ws.int) + ws.int + offset
-  
+
   xyplot.args <- list(
     x = myform,
     xlim = 1.03 * c(-span, span),
@@ -428,18 +424,18 @@ polarFreq <- function(mydata,
     as.table = TRUE,
     aspect = 1,
     scales = list(draw = FALSE),
-    
+
     panel = function(x, y, subscripts, ...) {
       panel.xyplot(x, y, ...)
-      
+
       subdata <- results.grid[subscripts, ]
-      
+
       for (i in 1:nrow(subdata)) {
         colour <- col[as.numeric(subdata$div[i])]
         #   if (subdata$weights[i] == 0) colour <- "transparent"
         poly(subdata$wd[i], subdata$ws[i], colour)
       }
-      
+
       ## annotate
       if (ws.int < max.ws) { ## don't annotate if only 1 interval
         angles <- seq(0, 2 * pi, length = 360)
@@ -449,7 +445,7 @@ polarFreq <- function(mydata,
             (offset + x) * cos(angles),
             col = "grey", lty = 5
           ))
-        
+
         ## radial labels
         sapply(seq(0, 20 * grid.line, by = grid.line), function(x)
           ltext(
@@ -458,12 +454,12 @@ polarFreq <- function(mydata,
             cex = 0.7
           ))
       }
-      
+
       larrows(-span, 0, -offset, 0, code = 1, length = 0.1)
       larrows(span, 0, offset, 0, code = 1, length = 0.1)
       larrows(0, -span, 0, -offset, code = 1, length = 0.1)
       larrows(0, span, 0, offset, code = 1, length = 0.1)
-      
+
       ltext(-span * 0.95, 0.07 * span, "W", cex = 0.7)
       ltext(0.07 * span, -span * 0.95, "S", cex = 0.7)
       ltext(0.07 * span, span * 0.95, "N", cex = 0.7)
@@ -471,14 +467,14 @@ polarFreq <- function(mydata,
     },
     legend = legend
   )
-  
+
   # reset for extra.args
   xyplot.args <- listUpdate(xyplot.args, extra.args)
-  
+
   # plot
   plt <- do.call(xyplot, xyplot.args)
-  
-  
+
+
   #################
   ## output
   #################
@@ -493,6 +489,6 @@ polarFreq <- function(mydata,
                  data = newdata,
                  call = match.call())
   class(output) <- "openair"
-  
+
   invisible(output)
 }

--- a/R/trajPlot.R
+++ b/R/trajPlot.R
@@ -123,10 +123,10 @@
 ##' # or show each day grouped by colour, with some other options set
 ##' \dontrun{
 ##'  trajPlot(selectByDate(lond, start = "15/4/2010", end = "21/4/2010"),
-##' group = "day", col = "jet", lwd = 2, key.pos = "right", key.col = 1)
+##' group = "day", col = "turbo", lwd = 2, key.pos = "right", key.col = 1)
 ##' }
 ##' # more examples to follow linking with concentration measurements...
-##' 
+##'
 trajPlot <- function(mydata, lon = "lon", lat = "lat", pollutant = "height",
                      type = "default", map = TRUE, group = NA, map.fill = TRUE,
                      map.res = "default", map.cols = "grey40",
@@ -155,7 +155,7 @@ trajPlot <- function(mydata, lon = "lon", lat = "lat", pollutant = "height",
   }
 
   mydata <- checkPrep(mydata, vars, type, remove.calm = FALSE)
-  
+
   mydata <- filter(mydata, !is.na(lat), !is.na(lon))
 
   ## slect only full length trajectories
@@ -191,7 +191,7 @@ trajPlot <- function(mydata, lon = "lon", lat = "lat", pollutant = "height",
 
   ## reset graphic parameters
   on.exit(trellis.par.set(
-     
+
     fontsize = current.font
   ))
 

--- a/man/openColours.Rd
+++ b/man/openColours.Rd
@@ -8,12 +8,12 @@ openColours(scheme = "default", n = 100)
 }
 \arguments{
 \item{scheme}{The pre-defined schemes are "increment", "default", "brewer1",
-  "heat", "jet", "hue", "greyscale", or a vector of R colour names e.g.
-  c("green", "blue"). It is also possible to supply colour schemes from the
-  \code{RColorBrewer} package. This package defines three types of colour
-  schemes: sequential, diverging or qualitative. See
-  \url{https://colorbrewer2.org/} for more details concerning the orginal work
-  on which this is based.
+  "heat", "jet", "turbo", "hue", "greyscale", or a vector of R colour names
+  e.g. c("green", "blue"). It is also possible to supply colour schemes from
+  the \code{RColorBrewer} package. This package defines three types of
+  colour schemes: sequential, diverging or qualitative. See
+  \url{https://colorbrewer2.org/} for more details concerning the orginal
+  work on which this is based.
 
   Simplified versions of the \code{viridis} colours are also available.
   These include "viridis", "plasma", "magma", "inferno" and "cividis".
@@ -57,9 +57,9 @@ user-defined length.
 
 Each of the pre-defined schemes have merits and their use will depend on a
 particular situation. For showing incrementing concentrations e.g. high
-concentrations emphasised, then "default", "heat", "jet" and "increment" are
-very useful. See also the description of \code{RColorBrewer} schemes for the
-option \code{scheme}.
+concentrations emphasised, then "default", "heat", "jet", "turbo", and
+"increment" are very useful. See also the description of \code{RColorBrewer}
+schemes for the option \code{scheme}.
 
 To colour-code categorical-type problems e.g. colours for different
 pollutants, "hue" and "brewer1" are useful.

--- a/man/polarFreq.Rd
+++ b/man/polarFreq.Rd
@@ -38,19 +38,17 @@ a data frame should be supplied e.g. \code{pollutant = "nox"}}
 \item{statistic}{The statistic that should be applied to each wind
 speed/direction bin. Can be \dQuote{frequency}, \dQuote{mean},
 \dQuote{median}, \dQuote{max} (maximum), \dQuote{stdev} (standard
-deviation) or \dQuote{weighted.mean}. The option
-\dQuote{frequency} (the default) is the simplest and plots the
-frequency of wind speed/direction in different bins. The scale
-therefore shows the counts in each bin. The option \dQuote{mean}
-will plot the mean concentration of a pollutant (see next point)
-in wind speed/direction bins, and so on.  Finally,
-\dQuote{weighted.mean} will plot the concentration of a pollutant
-weighted by wind speed/direction. Each segment therefore provides
-the percentage overall contribution to the total concentration.
-More information is given in the examples. Note that for options
-other than \dQuote{frequency}, it is necessary to also provide the
-name of a pollutant. See function \code{cutData} for further
-details.}
+deviation) or \dQuote{weighted.mean}. The option \dQuote{frequency} (the
+default) is the simplest and plots the frequency of wind speed/direction
+in different bins. The scale therefore shows the counts in each bin. The
+option \dQuote{mean} will plot the mean concentration of a pollutant (see
+next point) in wind speed/direction bins, and so on.  Finally,
+\dQuote{weighted.mean} will plot the concentration of a pollutant weighted
+by wind speed/direction. Each segment therefore provides the percentage
+overall contribution to the total concentration. More information is given
+in the examples. Note that for options other than \dQuote{frequency}, it
+is necessary to also provide the name of a pollutant. See function
+\code{cutData} for further details.}
 
 \item{ws.int}{Wind speed interval assumed. In some cases e.g. a low met
 mast, an interval of 0.5 may be more appropriate.}
@@ -60,51 +58,50 @@ mast, an interval of 0.5 may be more appropriate.}
 \item{grid.line}{Radial spacing of grid lines.}
 
 \item{breaks}{The user can provide their own scale. \code{breaks} expects a
-sequence of numbers that define the range of the scale. The sequence
-could represent one with equal spacing e.g. \code{breaks = seq(0, 100,
-10)} - a scale from 0-10 in intervals of 10, or a more flexible sequence
-e.g. \code{breaks = c(0, 1, 5, 7, 10)}, which may be useful for some
+sequence of numbers that define the range of the scale. The sequence could
+represent one with equal spacing e.g. \code{breaks = seq(0, 100, 10)} - a
+scale from 0-10 in intervals of 10, or a more flexible sequence e.g.
+\code{breaks = c(0, 1, 5, 7, 10)}, which may be useful for some
 situations.}
 
 \item{cols}{Colours to be used for plotting. Options include
-\dQuote{default}, \dQuote{increment}, \dQuote{heat}, \dQuote{jet}
-and \code{RColorBrewer} colours --- see the \code{openair}
-\code{openColours} function for more details. For user defined the
-user can supply a list of colour names recognised by R (type
-\code{colours()} to see the full list). An example would be
-\code{cols = c("yellow", "green", "blue")}}
+\dQuote{default}, \dQuote{increment}, \dQuote{heat}, \dQuote{jet},
+\dQuote{turbo}, and \code{RColorBrewer} colours --- see the \code{openair}
+\code{openColours} function for more details. For user defined the user
+can supply a list of colour names recognised by R (type \code{colours()}
+to see the full list). An example would be \code{cols = c("yellow",
+"green", "blue")}}
 
 \item{trans}{Should a transformation be applied? Sometimes when producing
-plots of this kind they can be dominated by a few high points. The
-default therefore is \code{TRUE} and a square-root transform is applied.
-This results in a non-linear scale and (usually) a better representation
-of the distribution. If set to \code{FALSE} a linear scale is used.}
+plots of this kind they can be dominated by a few high points. The default
+therefore is \code{TRUE} and a square-root transform is applied. This
+results in a non-linear scale and (usually) a better representation of the
+distribution. If set to \code{FALSE} a linear scale is used.}
 
-\item{type}{\code{type} determines how the data are split
-i.e. conditioned, and then plotted. The default is will produce a
-single plot using the entire data. Type can be one of the built-in
-types as detailed in \code{cutData} e.g. \dQuote{season},
-\dQuote{year}, \dQuote{weekday} and so on. For example, \code{type
-= "season"} will produce four plots --- one for each season.
+\item{type}{\code{type} determines how the data are split i.e. conditioned,
+  and then plotted. The default is will produce a single plot using the
+  entire data. Type can be one of the built-in types as detailed in
+  \code{cutData} e.g. \dQuote{season}, \dQuote{year}, \dQuote{weekday} and
+  so on. For example, \code{type = "season"} will produce four plots --- one
+  for each season.
 
-It is also possible to choose \code{type} as another variable in
-the data frame. If that variable is numeric, then the data will be
-split into four quantiles (if possible) and labelled
-accordingly. If type is an existing character or factor variable,
-then those categories/levels will be used directly. This offers
-great flexibility for understanding the variation of different
-variables and how they depend on one another.
+  It is also possible to choose \code{type} as another variable in the data
+  frame. If that variable is numeric, then the data will be split into four
+  quantiles (if possible) and labelled accordingly. If type is an existing
+  character or factor variable, then those categories/levels will be used
+  directly. This offers great flexibility for understanding the variation of
+  different variables and how they depend on one another.
 
-Type can be up length two e.g. \code{type = c("season", "weekday")} will
+  Type can be up length two e.g. \code{type = c("season", "weekday")} will
   produce a 2x2 plot split by season and day of the week. Note, when two
   types are provided the first forms the columns and the second the rows.}
 
 \item{min.bin}{The minimum number of points allowed in a wind speed/wind
-direction bin.  The default is 1. A value of two requires at least 2
-valid records in each bin an so on; bins with less than 2 valid records
-are set to NA. Care should be taken when using a value > 1 because of the
-risk of removing real data points. It is recommended to consider your
-data with care. Also, the \code{polarPlot} function can be of use in such
+direction bin.  The default is 1. A value of two requires at least 2 valid
+records in each bin an so on; bins with less than 2 valid records are set
+to NA. Care should be taken when using a value > 1 because of the risk of
+removing real data points. It is recommended to consider your data with
+care. Also, the \code{polarPlot} function can be of use in such
 circumstances.}
 
 \item{ws.upper}{A user-defined upper wind speed to use. This is useful for
@@ -112,11 +109,11 @@ ensuring a consistent scale between different plots. For example, to
 always ensure that wind speeds are displayed between 1-10, set
 \code{ws.int = 10}.}
 
-\item{offset}{\code{offset} controls the size of the \sQuote{hole}
-in the middle and is expressed as a percentage of the maximum wind
-speed. Setting a higher \code{offset} e.g. 50 is useful for
-\code{statistic = "weighted.mean"} when \code{ws.int} is greater
-than the maximum wind speed. See example below.}
+\item{offset}{\code{offset} controls the size of the \sQuote{hole} in the
+middle and is expressed as a percentage of the maximum wind speed. Setting
+a higher \code{offset} e.g. 50 is useful for \code{statistic =
+"weighted.mean"} when \code{ws.int} is greater than the maximum wind
+speed. See example below.}
 
 \item{border.col}{The colour of the boundary of each wind speed/direction
 bin. The default is transparent. Another useful choice sometimes is
@@ -137,24 +134,23 @@ and \code{"left"}.}
 
 \item{auto.text}{Either \code{TRUE} (default) or \code{FALSE}. If
 \code{TRUE} titles and axis labels will automatically try and format
-pollutant names and units properly e.g.  by subscripting the \sQuote{2}
-in NO2.}
+pollutant names and units properly e.g.  by subscripting the \sQuote{2} in
+NO2.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
-analysing data to extract plot components and plotting them in other
-ways.}
+analysing data to extract plot components and plotting them in other ways.}
 
 \item{\dots}{Other graphical parameters passed onto \code{lattice:xyplot}
 and \code{cutData}. For example, \code{polarFreq} passes the option
 \code{hemisphere = "southern"} on to \code{cutData} to provide southern
-(rather than default northern) hemisphere handling of \code{type = "season"}.
-Similarly, common axis and title labelling options (such as \code{xlab},
-\code{ylab}, \code{main}) are passed to \code{xyplot} via \code{quickText}
-to handle routine formatting.}
+(rather than default northern) hemisphere handling of \code{type =
+"season"}. Similarly, common axis and title labelling options (such as
+\code{xlab}, \code{ylab}, \code{main}) are passed to \code{xyplot} via
+\code{quickText} to handle routine formatting.}
 }
 \value{
-As well as generating the plot itself, \code{polarFreq} also
-  returns an object of class \dQuote{openair}. The object includes three main
+As well as generating the plot itself, \code{polarFreq} also returns
+  an object of class \dQuote{openair}. The object includes three main
   components: \code{call}, the command used to generate the plot;
   \code{data}, the data frame of summarised information used to make the
   plot; and \code{plot}, the plot itself. If retained, e.g. using
@@ -162,7 +158,7 @@ As well as generating the plot itself, \code{polarFreq} also
   recover the data, reproduce or rework the original plot or undertake
   further analysis.
 
-An openair output can be manipulated using a number of generic operations,
+  An openair output can be manipulated using a number of generic operations,
   including \code{print}, \code{plot} and \code{summary}.
 }
 \description{
@@ -174,24 +170,24 @@ using a range of commonly used statistics.
 \details{
 \code{polarFreq} is its default use provides details of wind speed and
 direction frequencies. In this respect it is similar to
-\code{\link{windRose}}, but considers wind direction intervals of 10
-degrees and a user-specified wind speed interval. The frequency of wind
+\code{\link{windRose}}, but considers wind direction intervals of 10 degrees
+and a user-specified wind speed interval. The frequency of wind
 speeds/directions formed by these \sQuote{bins} is represented on a colour
 scale.
 
 The \code{polarFreq} function is more flexible than either
-\code{\link{windRose}} or \code{\link{polarPlot}}. It can, for example,
-also consider pollutant concentrations (see examples below). Instead of the
+\code{\link{windRose}} or \code{\link{polarPlot}}. It can, for example, also
+consider pollutant concentrations (see examples below). Instead of the
 number of data points in each bin, the concentration can be shown. Further,
 a range of statistics can be used to describe each bin - see
 \code{statistic} above. Plotting mean concentrations is useful for source
 identification and is the same as \code{\link{polarPlot}} but without
 smoothing, which may be preferable for some data. Plotting with
 \code{statistic = "weighted.mean"} is particularly useful for understanding
-the relative importance of different source contributions. For example,
-high mean concentrations may be observed for high wind speed conditions,
-but the weighted mean concentration may well show that the contribution to
-overall concentrations is very low.
+the relative importance of different source contributions. For example, high
+mean concentrations may be observed for high wind speed conditions, but the
+weighted mean concentration may well show that the contribution to overall
+concentrations is very low.
 
 \code{polarFreq} also offers great flexibility with the scale used and the
 user has fine control over both the range, interval and colour.
@@ -215,7 +211,7 @@ min.bin = 2)}
 
 #windRose for just 2000 and 2003 with different colours
 \dontrun{polarFreq(subset(mydata, format(date, "\%Y") \%in\% c(2000, 2003)),
-type = "year", cols = "jet")}
+type = "year", cols = "turbo")}
 
 # user defined breaks from 0-700 in intervals of 100 (note linear scale)
 \dontrun{polarFreq(mydata, breaks = seq(0, 700, 100))}

--- a/man/trajPlot.Rd
+++ b/man/trajPlot.Rd
@@ -163,7 +163,7 @@ type = "day")
 # or show each day grouped by colour, with some other options set
 \dontrun{
  trajPlot(selectByDate(lond, start = "15/4/2010", end = "21/4/2010"),
-group = "day", col = "jet", lwd = 2, key.pos = "right", key.col = 1)
+group = "day", col = "turbo", lwd = 2, key.pos = "right", key.col = 1)
 }
 # more examples to follow linking with concentration measurements...
 


### PR DESCRIPTION
Added the "turbo" colour palette as an option to `openColours()`.

"turbo" was designed by Google to improve "jet" by having a more consistent lightness profile. It almost looks like a middle ground between "jet" and openair's "default" palette.

More info here: https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html

Note that "jet" hasn't been removed, so users can use either "jet" or "turbo".

![image](https://user-images.githubusercontent.com/45171616/202411701-f18b7b09-d68e-4a50-adc2-e90fd6fc062e.png)
