### PR TITLE
feat (R/trajCluster.R): return n/freq

### DIFF
--- a/R/trajCluster.R
+++ b/R/trajCluster.R
@@ -53,7 +53,10 @@
 #' @export
 #' @useDynLib openair, .registration = TRUE
 #' @import cluster
-#' @return an [openair][openair-package] object
+#' @return an [openair][openair-package] object. The `data` component contains
+#'   both `traj` (the original data appended with its cluster) and `results`
+#'   (the average trajectory path per cluster, shown in the `trajCluster()`
+#'   plot.)
 #' @family trajectory analysis functions
 #' @family cluster analysis functions
 #' @author David Carslaw
@@ -278,7 +281,15 @@ trajCluster <- function(traj, method = "Euclid", n.cluster = 5,
   plt <- do.call(scatterPlot, plot.args)
 
   ## create output with plot
-  output <- list(plot = plt, data = list(traj = traj, results = resRtn), call = match.call())
+  output <-
+    list(
+      plot = plt,
+      data = list(
+        traj = traj,
+        results = dplyr::left_join(resRtn, clusters, by = c("cluster", type))
+      ),
+      call = match.call()
+    )
   class(output) <- "openair"
   invisible(output)
 }

--- a/man/trajCluster.Rd
+++ b/man/trajCluster.Rd
@@ -100,7 +100,10 @@ and \code{cutData}. Similarly, common axis and title labelling options
 \code{levelplot} via \code{quickText} to handle routine formatting.}
 }
 \value{
-an \link[=openair-package]{openair} object
+an \link[=openair-package]{openair} object. The \code{data} component contains
+both \code{traj} (the original data appended with its cluster) and \code{results}
+(the average trajectory path per cluster, shown in the \code{trajCluster()}
+plot.)
 }
 \description{
 This function carries out cluster analysis of HYSPLIT back trajectories. The


### PR DESCRIPTION
At the moment, the frequency stats aren't returned in the `trajCluster()` data frame, and just exist on the plot. Hard to then use them for other stuff (including in `{ggopenair}`). 

Two changes:
- Attach freq stats to `results` df
- Mention in "returns" tag what the two `data` objects are

