### PR TITLE
Add "alpha" to directional analysis functions

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -6,7 +6,6 @@
 ^inst/web$
 ^docs$
 ^_pkgdown\.yml$
-NEWS\.md
 ^data-raw$
 README_files
 README_cache

--- a/NEWS
+++ b/NEWS
@@ -1,1 +1,0 @@
-This is a place holder. All openair news can be found at [here](https://github.com/davidcarslaw/openair/blob/master/NEWS.md)

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - make sure full daily gravimetric data are returned for PM10 and PM2.5 if vailable when using `importAURN` family of functions. These data will be returned as `gr_pm2.5` and `gr_pm10` if `data_type = "daily"`
 
+- add `alpha` argument to all polar directional analysis functions. This is mainly for use in `openairmaps` but may be of general interest for specific use cases.
+
 # openair 2.13
 
 - add `importLocal` to access locally-managed automatic monitoring data 

--- a/R/getMeta.R
+++ b/R/getMeta.R
@@ -45,7 +45,7 @@
 #'   a sequence e.g. \code{year = 2010:2020} or of length 2 e.g. \code{year =
 #'   c(2010, 2020)}, which will return only sites that were open over the
 #'   duration. Note that \code{year} is ignored when the \code{source} is either
-#'   \code{"kcl"} or \code{"europe}.
+#'   \code{"kcl"} or \code{"europe"}.
 #' @return A data frame with meta data.
 #' @author David Carslaw
 #' @family import functions
@@ -54,9 +54,8 @@
 #' @export
 #' @import readr
 #' @examples
-#' ## basic data
-#'
 #' \dontrun{
+#' # basic info
 #' meta <- importMeta(source = "aurn")
 #'
 #' # more detailed information:

--- a/R/percentileRose.R
+++ b/R/percentileRose.R
@@ -85,14 +85,32 @@
 #' # percentile concentrations by season and day/nighttime..
 #' percentileRose(mydata, type = c("season", "daylight"), pollutant = "o3", col = "brewer1")
 #' }
-percentileRose <- function(mydata, pollutant = "nox", wd = "wd", type = "default",
-                           percentile = c(25, 50, 75, 90, 95), smooth = FALSE,
-                           method = "default", cols = "default", angle = 10,
-                           mean = TRUE, mean.lty = 1, mean.lwd = 3, mean.col = "grey",
-                           fill = TRUE, intervals = NULL, angle.scale = 45,
-                           auto.text = TRUE, key.header = NULL,
-                           key.footer = "percentile", key.position = "bottom",
-                           key = TRUE, plot = TRUE, ...) {
+percentileRose <- function(
+    mydata,
+    pollutant = "nox",
+    wd = "wd",
+    type = "default",
+    percentile = c(25, 50, 75, 90, 95),
+    smooth = FALSE,
+    method = "default",
+    cols = "default",
+    angle = 10,
+    mean = TRUE,
+    mean.lty = 1,
+    mean.lwd = 3,
+    mean.col = "grey",
+    fill = TRUE,
+    intervals = NULL,
+    angle.scale = 45,
+    auto.text = TRUE,
+    key.header = NULL,
+    key.footer = "percentile",
+    key.position = "bottom",
+    key = TRUE,
+    alpha = 1,
+    plot = TRUE,
+    ...
+) {
 
   ## get rid of R check annoyances
   sub <- NULL
@@ -412,6 +430,9 @@ percentileRose <- function(mydata, pollutant = "nox", wd = "wd", type = "default
     height = 0.60, width = 1.5, fit = "scale",
     plot.style = "other"
   )
+  
+  col <- grDevices::adjustcolor(col, alpha.f = alpha)
+  
   legend <- makeOpenKeyLegend(key, legend, "percentileRose")
 
   if (mean.only || tolower(method) == "cpf") legend <- NULL

--- a/R/polarAnnulus.R
+++ b/R/polarAnnulus.R
@@ -141,17 +141,33 @@
 #' mydata$pmc <- mydata$pm10 - mydata$pm25
 #' \dontrun{polarAnnulus(mydata, poll="pmc", period = "trend",
 #' main = "trend in pmc at Marylebone Road")}
-polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
-                         local.tz = NULL, period = "hour", type = "default",
-                         statistic = "mean", percentile = NA,
-                         limits = c(0, 100), cols = "default",
-                         width = "normal", min.bin = 1, exclude.missing = TRUE,
-                         date.pad = FALSE, force.positive = TRUE,
-                         k = c(20, 10), normalise = FALSE,
-                         key.header = "", key.footer = pollutant,
-                         key.position = "right", key = TRUE,
-                         auto.text = TRUE, plot = TRUE, ...) {
-
+polarAnnulus <-
+  function(mydata,
+           pollutant = "nox",
+           resolution = "fine",
+           local.tz = NULL,
+           period = "hour",
+           type = "default",
+           statistic = "mean",
+           percentile = NA,
+           limits = c(0, 100),
+           cols = "default",
+           width = "normal",
+           min.bin = 1,
+           exclude.missing = TRUE,
+           date.pad = FALSE,
+           force.positive = TRUE,
+           k = c(20, 10),
+           normalise = FALSE,
+           key.header = "",
+           key.footer = pollutant,
+           key.position = "right",
+           key = TRUE,
+           auto.text = TRUE,
+           alpha = 1,
+           plot = TRUE,
+           ...) {
+    
   ## get rid of R check annoyances
   wd <- u <- v <- z <- all.dates <- NULL
 
@@ -374,149 +390,149 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
       percentile = tapply(mydata[, pollutant], list(time.cut, wd.cut), function(x)
         quantile(x, probs = percentile / 100, na.rm = TRUE))
     )
-
+    
     binned <- as.vector(binned)
-
+    
     ## frequency - remove points with freq < min.bin
     bin.len <- tapply(mydata[, pollutant], list(time.cut, wd.cut), length)
     binned.len <- as.vector(bin.len)
-
+    
     ids <- which(binned.len < min.bin)
     binned[ids] <- NA
-
+    
     ## data to predict over
     time.seq <- ws.wd$time.seq
     wd <- ws.wd$wd
-
+    
     input.data <- expand.grid(
       time.seq = seq(0, 10, length = len.int),
       wd = seq(0, 360, length = len.int)
     )
     ###################### Smoothing#################################################
-
+    
     ## run GAM to make a smooth surface
     if (force.positive) n <- 0.5 else n <- 1
-
+    
     input <- data.frame(binned, time.seq, wd)
-
+    
     ## note use of cyclic smooth for the wind direction component
     Mgam <- gam(binned ^ n ~ te(time.seq, wd, k = k, bs = c("tp", "cc")), data = input)
-
-
+    
+    
     pred <- predict.gam(Mgam, input.data)
     pred <- pred ^ (1 / n)
-
+    
     input.data <- cbind(input.data, pred)
-
+    
     if (exclude.missing) {
-
+      
       ## exclude predictions too far from data (from mgcv)
       x <- seq(0, 10, length = len.int)
       y <- seq(0, 360, length = len.int)
       res <- len.int
       wsp <- rep(x, res)
       wdp <- rep(y, rep(res, res))
-
+      
       #  ind <- exclude.too.far(wsp, wdp, mydata$trend, mydata$wd, dist = 0.03)
       ## data with gaps caused by min.bin
       all.data <- na.omit(data.frame(time.seq = ws.wd$time.seq, wd = ws.wd$wd, binned))
       ind <- with(all.data, exclude.too.far(wsp, wdp, time.seq, wd, dist = 0.03))
-
+      
       input.data$pred[ind] <- NA
       pred <- input.data$pred
     }
-
+    
     #############################################################################
     ## transform to new coords - probably more efficient way of doing this
     ## need to transform to/from annulus to a cartesian coords
-
+    
     ## new grid for plotting (the annulus)
     new.data <- expand.grid(
       u = seq(-upper - d, upper + d, by = int),
       v = seq(-upper - d, upper + d, by = int), z = NA, wd = NA,
       time.val = NA
     )
-
+    
     new.data$id <- seq(nrow(new.data))
-
+    
     ## calculate wd and time.val in on annulus in original units (helps with debugging)
     ## essentially start with final grid (annulus) and work backwards to find original data point in
     ## original coordinates
     new.data <- within(new.data, time.val <- (u ^ 2 + v ^ 2) ^ 0.5 - upper)
     new.data <- within(new.data, wd <- 180 * atan2(u, v) / pi)
     new.data <- within(new.data, wd[wd < 0] <- wd[wd < 0] + 360) ## correct negative wds
-
+    
     ## remove ids outside range
     ids <- with(new.data, which((u ^ 2 + v ^ 2) ^ 0.5 > d + upper | (u ^ 2 + v ^ 2) ^ 0.5
-    < upper))
+                                < upper))
     new.data$wd[ids] <- NA
     new.data$time.val[ids] <- NA
-
+    
     ## ids where there are data
     ids <- new.data$id[!is.na(new.data$wd)]
-
+    
     ## indexes in original (cartesian) coordinates
     id.time <- round((2 * d / int) * new.data$time.val[ids] / 10) + 1
     id.wd <- round((2 * d / int) * new.data$wd[ids] / 360) + 1
-
+    
     ## predicted values as a matrix
     pred <- matrix(pred, nrow = len.int, ncol = len.int)
-
+    
     ## match the ids with predictions
     new.data$z[ids] <- sapply(seq_along(ids), function(x) pred[id.time[x], id.wd[x]])
-
+    
     new.data
   }
-
+  
   ## more compact way?  Need to test
-
+  
   results.grid <- mydata %>%
     group_by(across(type)) %>%
     do(prepare.grid(.))
-
-
+  
+  
   ## normalise by divining by mean conditioning value if needed
   if (normalise) {
     results.grid <- results.grid %>%
       group_by(across(type)) %>%
       mutate(z = z / mean(z, na.rm = TRUE))
-
+    
     if (missing(key.footer)) key.footer <- "normalised \nlevel"
   }
-
+  
   ## proper names of labelling ###################################################
   strip.dat <- strip.fun(results.grid, type, auto.text)
   strip <- strip.dat[[1]]
   strip.left <- strip.dat[[2]]
   pol.name <- strip.dat[[3]]
-
-
+  
+  
   ## auto-scaling
   nlev <- 200 # preferred number of intervals
   ## handle missing breaks arguments
   if (missing(limits)) {
     # breaks <- pretty(results.grid$z, n = nlev)
     breaks <- seq(min(results.grid$z, na.rm = TRUE), max(results.grid$z, na.rm = TRUE),
-      length.out = nlev
+                  length.out = nlev
     )
     labs <- pretty(breaks, 7)
     labs <- labs[labs >= min(breaks) & labs <= max(breaks)]
     at <- labs
   } else {
-
+    
     ## handle user limits and clipping
     breaks <- seq(min(limits), max(limits), length.out = nlev)
     labs <- pretty(breaks, 7)
     labs <- labs[labs >= min(breaks) & labs <= max(breaks)]
     at <- labs
-
+    
     ## case where user max is < data max
     if (max(limits) < max(results.grid[["z"]], na.rm = TRUE)) {
       id <- which(results.grid[["z"]] > max(limits))
       results.grid[["z"]][id] <- max(limits)
       labs[length(labs)] <- paste(">", labs[length(labs)])
     }
-
+    
     ## case where user min is > data min
     if (min(limits) > min(results.grid[["z"]], na.rm = TRUE)) {
       id <- which(results.grid[["z"]] < min(limits))
@@ -524,12 +540,12 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
       labs[1] <- paste("<", labs[1])
     }
   }
-
+  
   nlev2 <- length(breaks)
-
+  
   col <- openColours(cols, (nlev2 - 1))
   col.scale <- breaks
-
+  
   #################
   ## scale key setup
   #################
@@ -539,12 +555,12 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
     footer = key.footer, header = key.header,
     height = 1, width = 1.5, fit = "all"
   )
-
+  
   legend <- makeOpenKeyLegend(key, legend, "polarAnnulus")
-
+  
   temp <- paste(type, collapse = "+")
   myform <- formula(paste("z ~ u * v | ", temp, sep = ""))
-
+  
   levelplot.args <- list(
     x = myform, results.grid, axes = FALSE,
     as.table = TRUE,
@@ -555,33 +571,38 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
     scales = list(draw = FALSE),
     strip = strip,
     sub = sub,
-
+    
     len <- upper + d + 3,
     xlim = c(-len, len), ylim = c(-len, len),
-
+    
     panel = function(x, y, z, subscripts, ...) {
-      panel.levelplot(x, y, z, subscripts,
+      panel.levelplot(
+        x, y, z,
+        subscripts,
         at = col.scale,
-        lwd = 1, col.regions = col, labels = FALSE
+        lwd = 1,
+        col.regions = col,
+        labels = FALSE,
+        alpha.regions = alpha
       )
-
+      
       ## add axis line to central polarPlot
       llines(c(upper, upper + d), c(0, 0), col = "grey20")
       llines(c(0, 0), c(-upper, -upper - d), col = "grey20")
-
+      
       ## add axis line to central polarPlot
       llines(c(0, 0), c(upper, upper + d), col = "grey20")
       llines(c(-upper, -upper - d), c(0, 0), col = "grey20")
-
+      
       add.tick <- function(n, start = 0, end = 0) {
         ## start is an offset if time series does not begin in January
-
+        
         ## left
         lsegments(seq(-upper - start, -upper - d + end, length = n),
-          rep(-.5, n),
-          seq(-upper - start, -upper - d + end, length = n),
-          rep(.5, n),
-          col = "grey20"
+                  rep(-.5, n),
+                  seq(-upper - start, -upper - d + end, length = n),
+                  rep(.5, n),
+                  col = "grey20"
         )
         ## top
         lsegments(
@@ -592,10 +613,10 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
         )
         ## right
         lsegments(seq(upper + start, upper + d - end, length = n),
-          rep(-.5, n),
-          seq(upper + start, upper + d - end, length = n),
-          rep(.5, n),
-          col = "grey20"
+                  rep(-.5, n),
+                  seq(upper + start, upper + d - end, length = n),
+                  rep(.5, n),
+                  col = "grey20"
         )
         ## bottom
         lsegments(
@@ -605,7 +626,7 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
           seq(-upper - start, -upper - d + end, length = n)
         )
       }
-
+      
       label.axis <- function(x, lab1, lab2, ticks) {
         ltext(x, upper, lab1, cex = 0.7, pos = 4)
         ltext(x, upper + d, lab2, cex = 0.7, pos = 4)
@@ -614,7 +635,7 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
         ltext(-x, -upper - d, lab2, cex = 0.7, pos = 2)
         add.tick(ticks)
       }
-
+      
       if (period == "trend") {
         if (date.pad) {
           date.start <- min(all.dates$date)
@@ -623,12 +644,12 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
           date.start <- min(mydata$date)
           date.end <- max(mydata$date)
         }
-
+        
         label.axis(0, format(date.start, "%d-%b-%Y"), format(date.end, "%d-%b-%Y"), 2)
-
+        
         ## add ticks at 1-Jan each year (could be missing dates)
         days <- seq(as.Date(date.start), as.Date(date.end), by = "day")
-
+        
         if (length(days) > 365) {
           ## find number of Januarys
           num.jans <- which(format(days, "%j") == "001")
@@ -636,7 +657,7 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
           start <- 10 * (num.jans[1] - 1) / length(days)
           end <- 10 - 10 * (num.jans[ticks] - 1) / length(days)
           if (length(num.jans) > 0) add.tick(ticks, start, end)
-
+          
           ## mark montly intervals (approx)
         } else {
           ## find number of 01s
@@ -647,23 +668,23 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
           if (length(num.jans) > 0) add.tick(ticks, start, end)
         }
       }
-
+      
       if (period == "season") {
         label.axis(
           0, format(ISOdate(2000, 1, 1), "%B"),
           format(ISOdate(2000, 12, 1), "%B"), 13
         )
       }
-
+      
       if (period == "hour") label.axis(0, "0", "23", 7)
-
+      
       if (period == "weekday") {
         local.weekdays <- format(ISOdate(2000, 1, 1:14), "%A")[order(format(ISOdate(2000, 1, 1:14), "%w"))]
         loc.sunday <- local.weekdays[1]
         loc.saturday <- local.weekdays[length(local.weekdays)]
         label.axis(0, loc.sunday, loc.saturday, 8)
       }
-
+      
       ## text for directions
       ltext(-upper - d - 1.5, 0, "W", cex = 0.7)
       ltext(0, -upper - d - 1.5, "S", cex = 0.7)
@@ -671,14 +692,14 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
       ltext(upper + d + 1.5, 0, "E", cex = 0.7)
     }
   )
-
+  
   # reset for extra.args
   levelplot.args <- listUpdate(levelplot.args, extra.args)
-
+  
   # plot
   plt <- do.call(levelplot, levelplot.args)
-
-
+  
+  
   #################
   # output
   #################
@@ -692,6 +713,6 @@ polarAnnulus <- function(mydata, pollutant = "nox", resolution = "fine",
   newdata <- results.grid
   output <- list(plot = plt, data = newdata, call = match.call())
   class(output) <- "openair"
-
+  
   invisible(output)
-}
+  }

--- a/R/polarDiff.R
+++ b/R/polarDiff.R
@@ -16,9 +16,9 @@
 #'
 #' @inheritParams polarPlot
 #' @param before A data frame that represents the "before" case. See
-#'   \code{\link{polarPlot}} for details of different input requirements.
-#' @param after A data frame that represents the "after" case. See
-#'   \code{\link{polarPlot}} for details of different input requirements.
+#'   [polarPlot()] for details of different input requirements.
+#' @param after A data frame that represents the "after" case. See [polarPlot()]
+#'   for details of different input requirements.
 #' @inheritDotParams polarPlot -pollutant -x -limits -plot
 #' @family polar directional analysis functions
 #' @return an [openair][openair-package] plot.
@@ -37,10 +37,16 @@
 #' polarDiff(before_data, after_data, pollutant = "no2", cols = "RdYlBu", limits = c(-20, 20))
 #'
 #' }
-polarDiff <- function(before, after, pollutant = "nox",
-                      x = "ws",
-                      limits = NA,
-                      plot = TRUE, ...) {
+polarDiff <- function(
+    before,
+    after,
+    pollutant = "nox",
+    x = "ws",
+    limits = NA,
+    alpha = 1,
+    plot = TRUE,
+    ...
+) {
 
   # extra args setup
   Args <- list(...)
@@ -66,6 +72,7 @@ polarDiff <- function(before, after, pollutant = "nox",
                       x = x,
                       type = "period",
                       plot = FALSE,
+                      alpha = alpha,
                       ...)
 
   polar_data <- pivot_wider(polar_plt$data,
@@ -100,7 +107,8 @@ polarDiff <- function(before, after, pollutant = "nox",
             x = x, plot = plot,
             cols = Args$cols,
             limits = Args$limits,
-            force.positive = FALSE)
+            force.positive = FALSE,
+            alpha = alpha)
 
   output <- list(data = polar_data, call = match.call())
 

--- a/R/polarFreq.R
+++ b/R/polarFreq.R
@@ -134,6 +134,7 @@ polarFreq <- function(mydata,
                       key.position = "right",
                       key = TRUE,
                       auto.text = TRUE,
+                      alpha = 1,
                       plot = TRUE,
                       ...) {
 
@@ -371,6 +372,7 @@ polarFreq <- function(mydata,
 
       for (i in 1:nrow(subdata)) {
         colour <- col[as.numeric(subdata$div[i])]
+        colour <- grDevices::adjustcolor(colour, alpha.f = alpha)
         #   if (subdata$weights[i] == 0) colour <- "transparent"
         poly(subdata$wd[i], subdata$ws[i], colour)
       }

--- a/R/polarPlot.R
+++ b/R/polarPlot.R
@@ -426,17 +426,41 @@
 #'
 #' @export
 polarPlot <-
-  function(mydata, pollutant = "nox", x = "ws", wd = "wd",
-           type = "default", statistic = "mean",
-           limits = NA, exclude.missing = TRUE, uncertainty = FALSE,
-           percentile = NA, cols = "default", weights = c(0.25, 0.5, 0.75),
-           min.bin = 1, mis.col = "grey", alpha = 1, upper = NA, angle.scale = 315,
-           units = x, force.positive = TRUE, k = 100, normalise = FALSE,
-           key.header = "", key.footer = pollutant, key.position = "right",
-           key = TRUE, auto.text = TRUE, ws_spread = 1.5, wd_spread = 5,
-           x_error = NA, y_error = NA,
-           kernel = "gaussian", tau = 0.5, plot = TRUE, ...) {
-
+  function(mydata,
+           pollutant = "nox",
+           x = "ws",
+           wd = "wd",
+           type = "default",
+           statistic = "mean",
+           limits = NA,
+           exclude.missing = TRUE,
+           uncertainty = FALSE,
+           percentile = NA,
+           cols = "default",
+           weights = c(0.25, 0.5, 0.75),
+           min.bin = 1,
+           mis.col = "grey",
+           upper = NA,
+           angle.scale = 315,
+           units = x,
+           force.positive = TRUE,
+           k = 100,
+           normalise = FALSE,
+           key.header = "",
+           key.footer = pollutant,
+           key.position = "right",
+           key = TRUE,
+           auto.text = TRUE,
+           ws_spread = 1.5,
+           wd_spread = 5,
+           x_error = NA,
+           y_error = NA,
+           kernel = "gaussian",
+           tau = 0.5,
+           alpha = 1,
+           plot = TRUE,
+           ...) {
+    
     ## get rid of R check annoyances
     z <- . <- NULL
 
@@ -1108,7 +1132,8 @@ polarPlot <-
           at = col.scale,
           pretty = TRUE,
           col.regions = col,
-          labels = FALSE, alpha.regions = alpha
+          labels = FALSE,
+          alpha.regions = alpha
         )
 
         angles <- seq(0, 2 * pi, length = 360)

--- a/R/windRose.R
+++ b/R/windRose.R
@@ -65,11 +65,20 @@
 #'
 #' ## results show postive bias in wd and ws
 #' pollutionRose(mydata, ws = "ws", wd = "wd", ws2 = "ws2", wd2 = "wd2")
-pollutionRose <- function(mydata, pollutant = "nox", key.footer = pollutant,
-                          key.position = "right", key = TRUE,
-                          breaks = 6, paddle = FALSE, seg = 0.9, normalise = FALSE,
-                          plot = TRUE,
-                          ...) {
+pollutionRose <- function(
+    mydata,
+    pollutant = "nox",
+    key.footer = pollutant,
+    key.position = "right",
+    key = TRUE,
+    breaks = 6,
+    paddle = FALSE,
+    seg = 0.9,
+    normalise = FALSE,
+    alpha = 1,
+    plot = TRUE,
+    ...
+) {
 
   ## extra args setup
   extra <- list(...)
@@ -98,7 +107,7 @@ pollutionRose <- function(mydata, pollutant = "nox", key.footer = pollutant,
     mydata,
     pollutant = pollutant, paddle = paddle, seg = seg,
     key.position = key.position, key.footer = key.footer, key = key,
-    breaks = breaks, normalise = normalise, plot = plot, ...
+    breaks = breaks, normalise = normalise, alpha = alpha, plot = plot, ...
   )
 }
 
@@ -126,7 +135,7 @@ pollutionRose <- function(mydata, pollutant = "nox", key.footer = pollutant,
 #' The option \code{statistic = "prop.mean"} provides a measure of the relative
 #' contribution of each bin to the panel mean, and is intended for use with
 #' \code{pollutionRose}.
-#'
+#' 
 #' @param mydata A data frame containing fields \code{ws} and \code{wd}
 #' @param ws Name of the column representing wind speed.
 #' @param wd Name of the column representing wind direction.
@@ -238,6 +247,10 @@ pollutionRose <- function(mydata, pollutant = "nox", key.footer = pollutant,
 #'   (between 0 and 360 degrees) to mitigate such problems. For example
 #'   \code{angle.scale = 45} will draw the scale heading in a NE direction.
 #' @param border Border colour for shaded areas. Default is no border.
+#' @param alpha The alpha transparency to use for the plotting surface (a value
+#'   between 0 and 1 with zero being fully transparent and 1 fully opaque).
+#'   Setting a value below 1 can be useful when plotting surfaces on a map using
+#'   the package \code{openairmapss}.
 #' @param plot Should a plot be produced? \code{FALSE} can be useful when
 #'   analysing data to extract plot components and plotting them in other ways.
 #' @param ... Other parameters that are passed on to \code{drawOpenKey},
@@ -280,16 +293,41 @@ pollutionRose <- function(mydata, pollutant = "nox", key.footer = pollutant,
 #' \dontrun{
 #' windRose(mydata, angle = 10, width = 0.2, grid.line = 1)
 #' }
-windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
-                     ws.int = 2, angle = 30, type = "default", bias.corr = TRUE,
-                     cols = "default", grid.line = NULL, width = 1, seg = NULL,
-                     auto.text = TRUE, breaks = 4, offset = 10, normalise = FALSE,
-                     max.freq = NULL, paddle = TRUE, key.header = NULL,
-                     key.footer = "(m/s)", key.position = "bottom",
-                     key = TRUE, dig.lab = 5, include.lowest = FALSE, statistic = "prop.count",
-                     pollutant = NULL, annotate = TRUE, angle.scale = 315, border = NA,
-                     plot = TRUE,
-                     ...) {
+windRose <- function(
+    mydata,
+    ws = "ws",
+    wd = "wd",
+    ws2 = NA,
+    wd2 = NA,
+    ws.int = 2,
+    angle = 30,
+    type = "default",
+    bias.corr = TRUE,
+    cols = "default",
+    grid.line = NULL,
+    width = 1,
+    seg = NULL,
+    auto.text = TRUE,
+    breaks = 4,
+    offset = 10,
+    normalise = FALSE,
+    max.freq = NULL,
+    paddle = TRUE,
+    key.header = NULL,
+    key.footer = "(m/s)",
+    key.position = "bottom",
+    key = TRUE,
+    dig.lab = 5,
+    include.lowest = FALSE,
+    statistic = "prop.count",
+    pollutant = NULL,
+    annotate = TRUE,
+    angle.scale = 315,
+    border = NA,
+    alpha = 1,
+    plot = TRUE,
+    ...
+) {
   if (is.null(seg)) seg <- 0.9
 
   ## greyscale handling
@@ -680,6 +718,9 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
   } else {
     col <- openColours(cols, length(labs))
   }
+  
+  legend_col <- col
+  col <- grDevices::adjustcolor(col, alpha.f = alpha)
 
   ## normalise by sector
 
@@ -719,7 +760,7 @@ windRose <- function(mydata, ws = "ws", wd = "wd", ws2 = NA, wd2 = NA,
 
   ## key, colorkey, legend
   legend <- list(
-    col = col, space = key.position, auto.text = auto.text,
+    col = legend_col, space = key.position, auto.text = auto.text,
     labels = labs, footer = key.footer, header = key.header,
     height = 0.60, width = 1.5, fit = "scale",
     plot.style = if (paddle) "paddle" else "other"

--- a/man/importMeta.Rd
+++ b/man/importMeta.Rd
@@ -26,7 +26,7 @@ measured a particular pollutant in that year are returned. Year can also be
 a sequence e.g. \code{year = 2010:2020} or of length 2 e.g. \code{year =
   c(2010, 2020)}, which will return only sites that were open over the
 duration. Note that \code{year} is ignored when the \code{source} is either
-\code{"kcl"} or \code{"europe}.}
+\code{"kcl"} or \code{"europe"}.}
 }
 \value{
 A data frame with meta data.
@@ -58,9 +58,8 @@ Thanks go to Trevor Davies (Ricardo), Dr Stuart Grange (EMPA) and Dr Ben
 Barratt (KCL) and  for making these data available.
 }
 \examples{
-## basic data
-
 \dontrun{
+# basic info
 meta <- importMeta(source = "aurn")
 
 # more detailed information:

--- a/man/percentileRose.Rd
+++ b/man/percentileRose.Rd
@@ -26,6 +26,7 @@ percentileRose(
   key.footer = "percentile",
   key.position = "bottom",
   key = TRUE,
+  alpha = 1,
   plot = TRUE,
   ...
 )
@@ -123,6 +124,11 @@ and \code{"left"}.}
 
 \item{key}{Fine control of the scale key via \code{drawOpenKey}. See
 \code{drawOpenKey} for further details.}
+
+\item{alpha}{The alpha transparency to use for the plotting surface (a value
+between 0 and 1 with zero being fully transparent and 1 fully opaque).
+Setting a value below 1 can be useful when plotting surfaces on a map using
+the package \code{openairmapss}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}

--- a/man/polarAnnulus.Rd
+++ b/man/polarAnnulus.Rd
@@ -27,6 +27,7 @@ polarAnnulus(
   key.position = "right",
   key = TRUE,
   auto.text = TRUE,
+  alpha = 1,
   plot = TRUE,
   ...
 )
@@ -197,6 +198,11 @@ and \code{"left"}.}
 \item{auto.text}{Either \code{TRUE} (default) or \code{FALSE}. If \code{TRUE}
 titles and axis labels will automatically try and format pollutant names
 and units properly e.g.  by subscripting the `2' in NO2.}
+
+\item{alpha}{The alpha transparency to use for the plotting surface (a value
+between 0 and 1 with zero being fully transparent and 1 fully opaque).
+Setting a value below 1 can be useful when plotting surfaces on a map using
+the package \code{openairmapss}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}

--- a/man/polarDiff.Rd
+++ b/man/polarDiff.Rd
@@ -10,16 +10,17 @@ polarDiff(
   pollutant = "nox",
   x = "ws",
   limits = NA,
+  alpha = 1,
   plot = TRUE,
   ...
 )
 }
 \arguments{
 \item{before}{A data frame that represents the "before" case. See
-\code{\link{polarPlot}} for details of different input requirements.}
+\code{\link[=polarPlot]{polarPlot()}} for details of different input requirements.}
 
-\item{after}{A data frame that represents the "after" case. See
-\code{\link{polarPlot}} for details of different input requirements.}
+\item{after}{A data frame that represents the "after" case. See \code{\link[=polarPlot]{polarPlot()}}
+for details of different input requirements.}
 
 \item{pollutant}{Mandatory. A pollutant name corresponding to a variable in a
 data frame should be supplied e.g. \code{pollutant = "nox"}. There can also
@@ -42,6 +43,11 @@ automatically. However, there are circumstances when the user will wish to
 set different ones. An example would be a series of plots showing each year
 of data separately. The limits are set in the form \code{c(lower, upper)},
 so \code{limits = c(0, 100)} would force the plot limits to span 0-100.}
+
+\item{alpha}{The alpha transparency to use for the plotting surface (a value
+between 0 and 1 with zero being fully transparent and 1 fully opaque).
+Setting a value below 1 can be useful when plotting surfaces on a map using
+the package \code{openairmapss}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}
@@ -196,10 +202,6 @@ circumstances.}
 are removed on the plots. This is done by shading the missing data in
 \code{mis.col}. To not highlight missing data when \code{min.bin} > 1
 choose \code{mis.col = "transparent"}.}
-    \item{\code{alpha}}{The alpha transparency to use for the plotting surface (a value
-between 0 and 1 with zero being fully transparent and 1 fully opaque).
-Setting a value below 1 can be useful when plotting surfaces on a map using
-the package \code{openairmapss}.}
     \item{\code{upper}}{This sets the upper limit wind speed to be used. Often there are
 only a relatively few data points at very high wind speeds and plotting all
 of them can reduce the useful information in the plot.}

--- a/man/polarFreq.Rd
+++ b/man/polarFreq.Rd
@@ -24,6 +24,7 @@ polarFreq(
   key.position = "right",
   key = TRUE,
   auto.text = TRUE,
+  alpha = 1,
   plot = TRUE,
   ...
 )
@@ -139,6 +140,11 @@ and \code{"left"}.}
 \item{auto.text}{Either \code{TRUE} (default) or \code{FALSE}. If \code{TRUE}
 titles and axis labels will automatically try and format pollutant names
 and units properly e.g.  by subscripting the `2' in NO2.}
+
+\item{alpha}{The alpha transparency to use for the plotting surface (a value
+between 0 and 1 with zero being fully transparent and 1 fully opaque).
+Setting a value below 1 can be useful when plotting surfaces on a map using
+the package \code{openairmapss}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}

--- a/man/polarPlot.Rd
+++ b/man/polarPlot.Rd
@@ -19,7 +19,6 @@ polarPlot(
   weights = c(0.25, 0.5, 0.75),
   min.bin = 1,
   mis.col = "grey",
-  alpha = 1,
   upper = NA,
   angle.scale = 315,
   units = x,
@@ -37,6 +36,7 @@ polarPlot(
   y_error = NA,
   kernel = "gaussian",
   tau = 0.5,
+  alpha = 1,
   plot = TRUE,
   ...
 )
@@ -222,11 +222,6 @@ are removed on the plots. This is done by shading the missing data in
 \code{mis.col}. To not highlight missing data when \code{min.bin} > 1
 choose \code{mis.col = "transparent"}.}
 
-\item{alpha}{The alpha transparency to use for the plotting surface (a value
-between 0 and 1 with zero being fully transparent and 1 fully opaque).
-Setting a value below 1 can be useful when plotting surfaces on a map using
-the package \code{openairmapss}.}
-
 \item{upper}{This sets the upper limit wind speed to be used. Often there are
 only a relatively few data points at very high wind speeds and plotting all
 of them can reduce the useful information in the plot.}
@@ -309,6 +304,11 @@ supported but this may be enhanced in the future.}
 \item{tau}{The quantile to be estimated when \code{statistic} is set to
 \code{"quantile.slope"}. Default is \code{0.5} which is equal to the median
 and will be ignored if \code{"quantile.slope"} is not used.}
+
+\item{alpha}{The alpha transparency to use for the plotting surface (a value
+between 0 and 1 with zero being fully transparent and 1 fully opaque).
+Setting a value below 1 can be useful when plotting surfaces on a map using
+the package \code{openairmapss}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}

--- a/man/pollutionRose.Rd
+++ b/man/pollutionRose.Rd
@@ -14,6 +14,7 @@ pollutionRose(
   paddle = FALSE,
   seg = 0.9,
   normalise = FALSE,
+  alpha = 1,
   plot = TRUE,
   ...
 )
@@ -52,6 +53,11 @@ equal one. This is useful for showing how the concentrations (or other
 parameters) contribute to each wind sector when the proportion of time the
 wind is from that direction is low. A line showing the probability that the
 wind directions is from a particular wind sector is also shown.}
+
+\item{alpha}{The alpha transparency to use for the plotting surface (a value
+between 0 and 1 with zero being fully transparent and 1 fully opaque).
+Setting a value below 1 can be useful when plotting surfaces on a map using
+the package \code{openairmapss}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}

--- a/man/windRose.Rd
+++ b/man/windRose.Rd
@@ -35,6 +35,7 @@ windRose(
   annotate = TRUE,
   angle.scale = 315,
   border = NA,
+  alpha = 1,
   plot = TRUE,
   ...
 )
@@ -179,6 +180,11 @@ feature. The user can therefore set \code{angle.scale} to another value
 \code{angle.scale = 45} will draw the scale heading in a NE direction.}
 
 \item{border}{Border colour for shaded areas. Default is no border.}
+
+\item{alpha}{The alpha transparency to use for the plotting surface (a value
+between 0 and 1 with zero being fully transparent and 1 fully opaque).
+Setting a value below 1 can be useful when plotting surfaces on a map using
+the package \code{openairmapss}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}


### PR DESCRIPTION
Added the `alpha` argument to `polarAnnulus()`, `polarFreq()`, `polarDiff()`, `percentileRose()`, `windRose()` and `pollutionRose()`. These are all useful and necessary in `openairmaps` - see https://github.com/davidcarslaw/openairmaps/commit/49af773b068591630202fd4a60ac13df92d0a862 - especially now the issue with alpha on non-Mac OS has been fixed - see https://github.com/davidcarslaw/openairmaps/commit/97cc3c736fc0206e5f68b4d0f3350f0988da3b5b.

![image](https://user-images.githubusercontent.com/45171616/212554726-79001974-7121-42c8-982b-d0c7448d6a40.png)

Also:
* Fixed typo in `importMeta()` that was causing R CMD issues (no closing quotation mark).
* Updated `NEWS.md` with this alpha update.
* Deleted `NEWS` placeholder and revised `.Rbuildignore`, which seem to be legacies from a time before `NEWS.md` was allowed by CRAN.