### PR TITLE
fix (R/polarDiff.R): return plot

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: openair
 Type: Package
 Title: Tools for the Analysis of Air Pollution Data
-Version: 2.14
+Version: 2.14.0.9000
 Date: 2023-01-25
 Authors@R: c(person("David", "Carslaw", role = c("aut", "cre"), email =
     "david.carslaw@york.ac.uk"), person("Jack", "Davison", role =

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# openair (development version)
+
+- fix issue with `polarDiff()` where the resulting `openair` object did not contain the `plot` element.
+
 # openair 2.13-99
 
 - add `year` as an option to `importMeta`. This allows the user to select sites that were only open at some point in the chosen year or duration of years.

--- a/R/polarDiff.R
+++ b/R/polarDiff.R
@@ -68,12 +68,12 @@ polarDiff <- function(
   all_data <- bind_rows(before, after)
 
   polar_plt <- polarPlot(all_data,
-                      pollutant = pollutant,
-                      x = x,
-                      type = "period",
-                      plot = FALSE,
-                      alpha = alpha,
-                      ...)
+                         pollutant = pollutant,
+                         x = x,
+                         type = "period",
+                         plot = FALSE,
+                         alpha = alpha,
+                         ...)
 
   polar_data <- pivot_wider(polar_plt$data,
                             id_cols = u:v,
@@ -102,17 +102,16 @@ polarDiff <- function(
     Args$new_limits
   }
 
+  plt <-
+    polarPlot(polar_data, pollutant = pollutant,
+              x = x, plot = plot,
+              cols = Args$cols,
+              limits = Args$limits,
+              force.positive = FALSE,
+              alpha = alpha)
 
-  polarPlot(polar_data, pollutant = pollutant,
-            x = x, plot = plot,
-            cols = Args$cols,
-            limits = Args$limits,
-            force.positive = FALSE,
-            alpha = alpha)
-
-  output <- list(data = polar_data, call = match.call())
+  output <- list(plot = plt$plot, data = polar_data, call = match.call())
 
   invisible(output)
-
 }
 


### PR DESCRIPTION
Fix an issue with polarDiff wherein the resulting plot was not returned with the openair object.

Previously one couldn't do the below code, because `diffobj` didn't contain `plot`.

```r
diffobj <- openair::polarDiff(before, after)
diffobj$plot
```