### PR TITLE
R/polarDiff.R refinements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: openair
 Type: Package
 Title: Tools for the Analysis of Air Pollution Data
-Version: 2.14
+Version: 2.14.0.9000
 Date: 2023-01-25
 Authors@R: c(person("David", "Carslaw", role = c("aut", "cre"), email =
     "david.carslaw@york.ac.uk"), person("Jack", "Davison", role =

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# openair (development version)
+
+- fix issue with `polarDiff()` where the resulting `openair` object did not contain the `plot` element.
+
 # openair 2.13-99
 
 - add `year` as an option to `importMeta`. This allows the user to select sites that were only open at some point in the chosen year or duration of years.

--- a/R/polarDiff.R
+++ b/R/polarDiff.R
@@ -43,7 +43,6 @@ polarDiff <- function(
     pollutant = "nox",
     x = "ws",
     limits = NA,
-    alpha = 1,
     plot = TRUE,
     ...
 ) {
@@ -72,7 +71,6 @@ polarDiff <- function(
                          x = x,
                          type = "period",
                          plot = FALSE,
-                         alpha = alpha,
                          ...)
 
   polar_data <- pivot_wider(polar_plt$data,
@@ -85,6 +83,7 @@ polarDiff <- function(
            wd = ifelse(wd < 0, wd + 360, wd))
 
   # other arguments
+  # colours
   Args$cols <- if ("cols" %in% names(Args)) {
     Args$cols
   } else {
@@ -92,9 +91,9 @@ polarDiff <- function(
       "#F4C8C8", "#DA8A8B", "#AE4647", "#5F1415")
   }
 
+  # limits
   lims_adj <- pretty(seq(0, max(abs(polar_data[[pollutant]]), na.rm = TRUE), 5))
   lims_adj <- lims_adj[length(lims_adj) - 1]
-
 
   Args$limits <- if (is.na(Args$new_limits[1])) {
     c(-lims_adj, lims_adj)
@@ -102,14 +101,39 @@ polarDiff <- function(
     Args$new_limits
   }
 
+  # key (for openairmaps)
+  Args$key <- if ("key" %in% names(Args)) {
+    Args$key
+  } else {
+    TRUE
+  }
+
+  # par settings (for openairmaps)
+  Args$par.settings <- if ("par.settings" %in% names(Args)) {
+    Args$par.settings
+  } else {
+    list(axis.line = list(col = "black"))
+  }
+
+  # alpha (for openairmaps
+  Args$alpha <- if ("alpha" %in% names(Args)) {
+    Args$alpha
+  } else {
+    1
+  }
+
+  # final plot
   plt <-
     polarPlot(polar_data, pollutant = pollutant,
               x = x, plot = plot,
               cols = Args$cols,
               limits = Args$limits,
               force.positive = FALSE,
-              alpha = alpha)
+              alpha = Args$alpha,
+              key = Args$key,
+              par.settings = Args$par.settings)
 
+  # return
   output <- list(plot = plt$plot, data = polar_data, call = match.call())
 
   invisible(output)

--- a/R/polarDiff.R
+++ b/R/polarDiff.R
@@ -68,12 +68,12 @@ polarDiff <- function(
   all_data <- bind_rows(before, after)
 
   polar_plt <- polarPlot(all_data,
-                      pollutant = pollutant,
-                      x = x,
-                      type = "period",
-                      plot = FALSE,
-                      alpha = alpha,
-                      ...)
+                         pollutant = pollutant,
+                         x = x,
+                         type = "period",
+                         plot = FALSE,
+                         alpha = alpha,
+                         ...)
 
   polar_data <- pivot_wider(polar_plt$data,
                             id_cols = u:v,
@@ -102,17 +102,16 @@ polarDiff <- function(
     Args$new_limits
   }
 
+  plt <-
+    polarPlot(polar_data, pollutant = pollutant,
+              x = x, plot = plot,
+              cols = Args$cols,
+              limits = Args$limits,
+              force.positive = FALSE,
+              alpha = alpha)
 
-  polarPlot(polar_data, pollutant = pollutant,
-            x = x, plot = plot,
-            cols = Args$cols,
-            limits = Args$limits,
-            force.positive = FALSE,
-            alpha = alpha)
-
-  output <- list(data = polar_data, call = match.call())
+  output <- list(plot = plt$plot, data = polar_data, call = match.call())
 
   invisible(output)
-
 }
 

--- a/R/polarPlot.R
+++ b/R/polarPlot.R
@@ -244,7 +244,7 @@
 #' @param alpha The alpha transparency to use for the plotting surface (a value
 #'   between 0 and 1 with zero being fully transparent and 1 fully opaque).
 #'   Setting a value below 1 can be useful when plotting surfaces on a map using
-#'   the package \code{openairmapss}.
+#'   the package \code{openairmaps}.
 #'
 #' @param upper This sets the upper limit wind speed to be used. Often there are
 #'   only a relatively few data points at very high wind speeds and plotting all
@@ -460,7 +460,7 @@ polarPlot <-
            alpha = 1,
            plot = TRUE,
            ...) {
-    
+
     ## get rid of R check annoyances
     z <- . <- NULL
 
@@ -1648,13 +1648,13 @@ YorkFit <- function(input_data, X = "X", Y = "Y",
     sumTOP <- sum(wTOPint, na.rm = TRUE)
     sumBOT <- sum(wBOTint, na.rm = TRUE)
     b <- sumTOP / sumBOT
-    
+
     # zero or problematic data
-    if (anyNA(b, b.old)) 
+    if (anyNA(b, b.old))
       return(tibble(Intercept = NA, Slope = NA,
                     Int_error = NA, Slope_error = NA,
-                    OLS_slope = NA)) 
-    
+                    OLS_slope = NA))
+
     b.diff <- abs(b - b.old)
   }
 

--- a/R/windRose.R
+++ b/R/windRose.R
@@ -135,7 +135,7 @@ pollutionRose <- function(
 #' The option \code{statistic = "prop.mean"} provides a measure of the relative
 #' contribution of each bin to the panel mean, and is intended for use with
 #' \code{pollutionRose}.
-#' 
+#'
 #' @param mydata A data frame containing fields \code{ws} and \code{wd}
 #' @param ws Name of the column representing wind speed.
 #' @param wd Name of the column representing wind direction.
@@ -250,7 +250,7 @@ pollutionRose <- function(
 #' @param alpha The alpha transparency to use for the plotting surface (a value
 #'   between 0 and 1 with zero being fully transparent and 1 fully opaque).
 #'   Setting a value below 1 can be useful when plotting surfaces on a map using
-#'   the package \code{openairmapss}.
+#'   the package \code{openairmaps}.
 #' @param plot Should a plot be produced? \code{FALSE} can be useful when
 #'   analysing data to extract plot components and plotting them in other ways.
 #' @param ... Other parameters that are passed on to \code{drawOpenKey},
@@ -718,7 +718,7 @@ windRose <- function(
   } else {
     col <- openColours(cols, length(labs))
   }
-  
+
   legend_col <- col
   col <- grDevices::adjustcolor(col, alpha.f = alpha)
 
@@ -947,7 +947,7 @@ windRose <- function(
   }
 
   newdata <- as_tibble(results)
-  
+
   # give informative labels
   attr(newdata, "intervals") <- labs
 

--- a/man/percentileRose.Rd
+++ b/man/percentileRose.Rd
@@ -128,7 +128,7 @@ and \code{"left"}.}
 \item{alpha}{The alpha transparency to use for the plotting surface (a value
 between 0 and 1 with zero being fully transparent and 1 fully opaque).
 Setting a value below 1 can be useful when plotting surfaces on a map using
-the package \code{openairmapss}.}
+the package \code{openairmaps}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}

--- a/man/polarAnnulus.Rd
+++ b/man/polarAnnulus.Rd
@@ -202,7 +202,7 @@ and units properly e.g.  by subscripting the `2' in NO2.}
 \item{alpha}{The alpha transparency to use for the plotting surface (a value
 between 0 and 1 with zero being fully transparent and 1 fully opaque).
 Setting a value below 1 can be useful when plotting surfaces on a map using
-the package \code{openairmapss}.}
+the package \code{openairmaps}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}

--- a/man/polarCluster.Rd
+++ b/man/polarCluster.Rd
@@ -220,7 +220,7 @@ choose \code{mis.col = "transparent"}.}
     \item{\code{alpha}}{The alpha transparency to use for the plotting surface (a value
 between 0 and 1 with zero being fully transparent and 1 fully opaque).
 Setting a value below 1 can be useful when plotting surfaces on a map using
-the package \code{openairmapss}.}
+the package \code{openairmaps}.}
     \item{\code{upper}}{This sets the upper limit wind speed to be used. Often there are
 only a relatively few data points at very high wind speeds and plotting all
 of them can reduce the useful information in the plot.}

--- a/man/polarDiff.Rd
+++ b/man/polarDiff.Rd
@@ -10,7 +10,6 @@ polarDiff(
   pollutant = "nox",
   x = "ws",
   limits = NA,
-  alpha = 1,
   plot = TRUE,
   ...
 )
@@ -43,11 +42,6 @@ automatically. However, there are circumstances when the user will wish to
 set different ones. An example would be a series of plots showing each year
 of data separately. The limits are set in the form \code{c(lower, upper)},
 so \code{limits = c(0, 100)} would force the plot limits to span 0-100.}
-
-\item{alpha}{The alpha transparency to use for the plotting surface (a value
-between 0 and 1 with zero being fully transparent and 1 fully opaque).
-Setting a value below 1 can be useful when plotting surfaces on a map using
-the package \code{openairmapss}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}
@@ -202,6 +196,10 @@ circumstances.}
 are removed on the plots. This is done by shading the missing data in
 \code{mis.col}. To not highlight missing data when \code{min.bin} > 1
 choose \code{mis.col = "transparent"}.}
+    \item{\code{alpha}}{The alpha transparency to use for the plotting surface (a value
+between 0 and 1 with zero being fully transparent and 1 fully opaque).
+Setting a value below 1 can be useful when plotting surfaces on a map using
+the package \code{openairmaps}.}
     \item{\code{upper}}{This sets the upper limit wind speed to be used. Often there are
 only a relatively few data points at very high wind speeds and plotting all
 of them can reduce the useful information in the plot.}

--- a/man/polarFreq.Rd
+++ b/man/polarFreq.Rd
@@ -144,7 +144,7 @@ and units properly e.g.  by subscripting the `2' in NO2.}
 \item{alpha}{The alpha transparency to use for the plotting surface (a value
 between 0 and 1 with zero being fully transparent and 1 fully opaque).
 Setting a value below 1 can be useful when plotting surfaces on a map using
-the package \code{openairmapss}.}
+the package \code{openairmaps}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}

--- a/man/polarPlot.Rd
+++ b/man/polarPlot.Rd
@@ -308,7 +308,7 @@ and will be ignored if \code{"quantile.slope"} is not used.}
 \item{alpha}{The alpha transparency to use for the plotting surface (a value
 between 0 and 1 with zero being fully transparent and 1 fully opaque).
 Setting a value below 1 can be useful when plotting surfaces on a map using
-the package \code{openairmapss}.}
+the package \code{openairmaps}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}

--- a/man/pollutionRose.Rd
+++ b/man/pollutionRose.Rd
@@ -57,7 +57,7 @@ wind directions is from a particular wind sector is also shown.}
 \item{alpha}{The alpha transparency to use for the plotting surface (a value
 between 0 and 1 with zero being fully transparent and 1 fully opaque).
 Setting a value below 1 can be useful when plotting surfaces on a map using
-the package \code{openairmapss}.}
+the package \code{openairmaps}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}

--- a/man/windRose.Rd
+++ b/man/windRose.Rd
@@ -184,7 +184,7 @@ feature. The user can therefore set \code{angle.scale} to another value
 \item{alpha}{The alpha transparency to use for the plotting surface (a value
 between 0 and 1 with zero being fully transparent and 1 fully opaque).
 Setting a value below 1 can be useful when plotting surfaces on a map using
-the package \code{openairmapss}.}
+the package \code{openairmaps}.}
 
 \item{plot}{Should a plot be produced? \code{FALSE} can be useful when
 analysing data to extract plot components and plotting them in other ways.}


### PR DESCRIPTION
Two key fixes to `polarDiff()`:

1. Return the plot. Previously, the below chunk wouldn't work, because the plot wasn't returned in the openair object.

```r
out <- polarDiff(before, after)
out$plot
```

2. Honour the alpha/key/par.settings arguments, for the benefit of openairmaps.

![image](https://user-images.githubusercontent.com/45171616/216603956-9d6e5e49-43ef-4a51-a481-a63e5d7c19c1.png)
