### PR TITLE
Add `formula.label` argument to `polarPlot` function & #resolves #340

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Type: Package
 Package: openair
 Title: Tools for the Analysis of Air Pollution Data
-Version: 2.17.0.9003
-Date: 2023-05-02
+Version: 2.17.0.9004
+Date: 2023-05-31
 Authors@R: c(
     person("David", "Carslaw", , "david.carslaw@york.ac.uk", role = c("aut", "cre")),
     person("Jack", "Davison", , "jack.davison@ricardo.com", role = "aut"),

--- a/R/polarPlot.R
+++ b/R/polarPlot.R
@@ -323,6 +323,9 @@
 #' @param kernel Type of kernel used for the weighting procedure for when
 #'   correlation or regression techniques are used. Only \code{"gaussian"} is
 #'   supported but this may be enhanced in the future.
+#'   
+#' @param formula.label When pair-wise statistics such as regression slopes are
+#'   calculated and plotted, should a formula label be displayed? 
 #'
 #' @param tau The quantile to be estimated when \code{statistic} is set to
 #'   \code{"quantile.slope"}. Default is \code{0.5} which is equal to the median
@@ -453,6 +456,7 @@ polarPlot <-
            x_error = NA,
            y_error = NA,
            kernel = "gaussian",
+           formula.label = TRUE,
            tau = 0.5,
            alpha = 1,
            plot = TRUE,
@@ -1114,7 +1118,8 @@ polarPlot <-
       
       # add footnote formula if regression used
       page = function(n)
-        if (grepl("slope|intercept", statistic) & length(pollutant == 2)) {
+        if (formula.label & grepl("slope|intercept", statistic) & 
+            length(pollutant == 2)) {
         grid.text(
           quickText(paste0(
             "Formula: ", pollutant[1], " = m.", pollutant[2], " + c"

--- a/man/import_ukaq.Rd
+++ b/man/import_ukaq.Rd
@@ -221,19 +221,29 @@ FDMS PM2.5 (where available) is shown in the 'v2.5' column.
 \examples{
 
 ## import all pollutants from Marylebone Rd from 1990:2009
-\dontrun{mary <- importAURN(site = "my1", year = 2000:2009)}
+\dontrun{
+mary <- importAURN(site = "my1", year = 2000:2009)
+}
 
 ## import nox, no2, o3 from Marylebone Road and Nottingham Centre for 2000
-\dontrun{thedata <- importAURN(site = c("my1", "nott"), year = 2000,
-pollutant = c("nox", "no2", "o3"))}
+\dontrun{
+thedata <- importAURN(
+  site = c("my1", "nott"), year = 2000,
+  pollutant = c("nox", "no2", "o3")
+)
+}
 
 # Other functions work in the same way e.g. to import Cardiff Centre data
 
 # Import annual data over a period, make it narrow format and return site information
 
-\dontrun{aq <- importAURN(year = 2010:2020, data_type = "annual", meta = TRUE, to_narrow = TRUE)}
+\dontrun{
+aq <- importAURN(year = 2010:2020, data_type = "annual", meta = TRUE, to_narrow = TRUE)
+}
 
-\dontrun{cardiff <- importWAQN(site = "card", year = 2020)}
+\dontrun{
+cardiff <- importWAQN(site = "card", year = 2020)
+}
 }
 \seealso{
 Other import functions: 

--- a/man/polarCluster.Rd
+++ b/man/polarCluster.Rd
@@ -274,6 +274,8 @@ regression statistics are used such as \emph{r}. Default is \code{4}.}
     \item{\code{kernel}}{Type of kernel used for the weighting procedure for when
 correlation or regression techniques are used. Only \code{"gaussian"} is
 supported but this may be enhanced in the future.}
+    \item{\code{formula.label}}{When pair-wise statistics such as regression slopes are
+calculated and plotted, should a formula label be displayed?}
     \item{\code{tau}}{The quantile to be estimated when \code{statistic} is set to
 \code{"quantile.slope"}. Default is \code{0.5} which is equal to the median
 and will be ignored if \code{"quantile.slope"} is not used.}

--- a/man/polarDiff.Rd
+++ b/man/polarDiff.Rd
@@ -262,6 +262,8 @@ regression statistics are used such as \emph{r}. Default is \code{4}.}
     \item{\code{kernel}}{Type of kernel used for the weighting procedure for when
 correlation or regression techniques are used. Only \code{"gaussian"} is
 supported but this may be enhanced in the future.}
+    \item{\code{formula.label}}{When pair-wise statistics such as regression slopes are
+calculated and plotted, should a formula label be displayed?}
     \item{\code{tau}}{The quantile to be estimated when \code{statistic} is set to
 \code{"quantile.slope"}. Default is \code{0.5} which is equal to the median
 and will be ignored if \code{"quantile.slope"} is not used.}

--- a/man/polarPlot.Rd
+++ b/man/polarPlot.Rd
@@ -35,6 +35,7 @@ polarPlot(
   x_error = NA,
   y_error = NA,
   kernel = "gaussian",
+  formula.label = TRUE,
   tau = 0.5,
   alpha = 1,
   plot = TRUE,
@@ -299,6 +300,9 @@ regression statistics are used such as \emph{r}. Default is \code{4}.}
 \item{kernel}{Type of kernel used for the weighting procedure for when
 correlation or regression techniques are used. Only \code{"gaussian"} is
 supported but this may be enhanced in the future.}
+
+\item{formula.label}{When pair-wise statistics such as regression slopes are
+calculated and plotted, should a formula label be displayed?}
 
 \item{tau}{The quantile to be estimated when \code{statistic} is set to
 \code{"quantile.slope"}. Default is \code{0.5} which is equal to the median


### PR DESCRIPTION
Add `formula.label` argument to `polarPlot` function to allow for the complete absence of labels & useful when many panels/facets are used & resolves #340