### PR TITLE
feat: allow UKAQ to guess `source` of `site`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 - The `source` argument of `importUKAQ()` now defaults to `NULL`. This option allows the function to assign the `source` of each `site` itself, with some caveats:
 
-	- Ambiguous codes (e.g., `"AD1"`, which corresponds to a SAQN and locally managed site) will error. In this instance, users should define `source` manually.
+	- Ambiguous codes (e.g., `"AD1"`, which corresponds to a SAQN and locally managed site) will preferentially import from the national networks (AURN, then AQE/SAQN/WAQN/NIAQN) over locally-managed networks. To override this users should manually define `source`.
 
 	- Incorrect codes not found in `importMeta()` will error if `importUKAQ()` is left to assign the `source`.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
 # openair (development version)
 
+## New Features
+
+- The `source` argument of `importUKAQ()` now defaults to `NULL`. This option allows the function to assign the `source` of each `site` itself, with some caveats:
+
+	- Ambiguous codes (e.g., `"AD1"`, which corresponds to a SAQN and locally managed site) will error. In this instance, users should define `source` manually.
+
+	- When `data_type` is one of the aggregate types (e.g., `"annual"`) and a `site` isn't defined, a `source` must be provided.
+
+	- It is likely *slightly* slower for the function to assign `source` itself than for users to specify it themselves.
+
 ## Bug fixes
 
 - Fixed an issue wherein `importUKAQ()` would drop sites if importing from `local` sites *and* another network.

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,19 +6,25 @@
 
 	- Ambiguous codes (e.g., `"AD1"`, which corresponds to a SAQN and locally managed site) will error. In this instance, users should define `source` manually.
 
+	- Incorrect codes not found in `importMeta()` will error if `importUKAQ()` is left to assign the `source`.
+
 	- When `data_type` is one of the aggregate types (e.g., `"annual"`) and a `site` isn't defined, a `source` must be provided.
 
 	- It is likely *slightly* slower for the function to assign `source` itself than for users to specify it themselves.
+
+- The `formula.label` argument of `polarPlot()` will now control whether concentration information is printed when `statistic = "cpf"`.
 
 ## Bug fixes
 
 - Fixed an issue wherein `importUKAQ()` would drop sites if importing from `local` sites *and* another network.
 
+- `polarCluster()` will no longer error with multiple `pollutant`s and a single `n.clusters`.
+
 # openair 2.18-2
 
 ## New Features
 
-- add option to `corPlot` to carry through "use" option in `cor`.
+- add option to `corPlot()` to carry through "use" option in `cor`.
 
 ## Bug fixes
 

--- a/R/importUKAQ-utils.R
+++ b/R/importUKAQ-utils.R
@@ -414,19 +414,19 @@ filter_site_pollutant <- function(aq_data, site, pollutant, to_narrow, data_type
 #' @param site Sites passed to [importUKAQ()]
 #' @noRd
 guess_source <- function(site) {
-  ukaq_meta <- importMeta("ukaq") |>
-    dplyr::mutate(source = factor(.data$source, c("aurn", "saqn", "aqe", "waqn", "ni", "local"))) |>
-    dplyr::arrange(.data$source) |>
+  ukaq_meta <- importMeta("ukaq") %>%
+    dplyr::mutate(source = factor(.data$source, c("aurn", "saqn", "aqe", "waqn", "ni", "local"))) %>%
+    dplyr::arrange(.data$source) %>%
     dplyr::distinct(.data$site, .data$latitude, .data$longitude, .keep_all = TRUE)
   
   source_tbl <-
-    data.frame(code = toupper(site)) |>
+    data.frame(code = toupper(site)) %>%
     dplyr::left_join(ukaq_meta, by = "code")
 
   if (any(is.na(source_tbl$source))) {
     ambiguous_codes <-
-      source_tbl |> 
-      dplyr::filter(is.na(.data$source)) |>
+      source_tbl %>% 
+      dplyr::filter(is.na(.data$source)) %>%
       dplyr::pull(.data$code)
 
     cli::cli_abort(
@@ -439,12 +439,12 @@ guess_source <- function(site) {
 
   if (nrow(source_tbl) > length(site)) {
     ambiguous_codes <- 
-      source_tbl |>
-      dplyr::add_count(.data$code) |>
-      dplyr::filter(.data$n > 1L) |>
-      dplyr::group_by(.data$code) |>
-      dplyr::summarise(source = paste(.data$source, collapse = ", ")) |>
-      dplyr::mutate(str = paste0(.data$code, " (", .data$source, ")")) |>
+      source_tbl %>%
+      dplyr::add_count(.data$code) %>%
+      dplyr::filter(.data$n > 1L) %>%
+      dplyr::group_by(.data$code) %>%
+      dplyr::summarise(source = paste(.data$source, collapse = ", ")) %>%
+      dplyr::mutate(str = paste0(.data$code, " (", .data$source, ")")) %>%
       dplyr::pull(.data$str)
 
     cli::cli_abort(

--- a/R/importUKAQ-utils.R
+++ b/R/importUKAQ-utils.R
@@ -423,6 +423,20 @@ guess_source <- function(site) {
     data.frame(code = toupper(site)) |>
     dplyr::left_join(ukaq_meta, by = "code")
 
+  if (any(is.na(source_tbl$source))) {
+    ambiguous_codes <-
+      source_tbl |> 
+      dplyr::filter(is.na(.data$source)) |>
+      dplyr::pull(.data$code)
+
+    cli::cli_abort(
+      c(
+        "x" = "Unknown site codes detected. Please ensure all site codes can be found in {.fun importMeta}.",
+        "i" = "Unknown site codes: {ambiguous_codes}"
+      )
+    )
+  }
+
   if (nrow(source_tbl) > length(site)) {
     ambiguous_codes <- 
       source_tbl |>

--- a/R/importUKAQ-utils.R
+++ b/R/importUKAQ-utils.R
@@ -447,7 +447,7 @@ guess_source <- function(site) {
 
     alternatives <-
       source_tbl_other %>%
-      dplyr:::mutate(str = paste0(.data$code, " (could also be '", .data$site, "' from the source: '", .data$source, "'.)")) %>%
+      dplyr::mutate(str = paste0(.data$code, " (could also be '", .data$site, "' from the source: '", .data$source, "'.)")) %>%
       dplyr::pull(.data$str)
 
     msg <- c(

--- a/R/importUKAQ.R
+++ b/R/importUKAQ.R
@@ -95,8 +95,8 @@
 #'   `2000:2020`. To import several specific years use `year = c(2000, 2010,
 #'   2020)`.
 #' @param source The network to which the `site`(s) belong. The default, `NULL`,
-#'   allows [importUKAQ()] to guess the correct `source`. When this isn't possible
-#'   (for example, when the site code is ambiguous), users can provide a `source`.
+#'   allows [importUKAQ()] to guess the correct `source`, preferring national 
+#'   networks over locally managed networks. Alternatively, users can define a `source`.
 #'   Providing a single network will attempt to import all of the
 #'   given `site`s from the provided network. Alternatively, a vector of sources
 #'   can be provided of the same length as `site` to indicate which network each

--- a/man/importUKAQ.Rd
+++ b/man/importUKAQ.Rd
@@ -30,8 +30,8 @@ codes can be upper or lower case.}
 \code{2000:2020}. To import several specific years use \code{year = c(2000, 2010, 2020)}.}
 
 \item{source}{The network to which the \code{site}(s) belong. The default, \code{NULL},
-allows \code{\link[=importUKAQ]{importUKAQ()}} to guess the correct \code{source}. When this isn't possible
-(for example, when the site code is ambiguous), users can provide a \code{source}.
+allows \code{\link[=importUKAQ]{importUKAQ()}} to guess the correct \code{source}, preferring national
+networks over locally managed networks. Alternatively, users can define a \code{source}.
 Providing a single network will attempt to import all of the
 given \code{site}s from the provided network. Alternatively, a vector of sources
 can be provided of the same length as \code{site} to indicate which network each

--- a/man/importUKAQ.Rd
+++ b/man/importUKAQ.Rd
@@ -7,7 +7,7 @@
 importUKAQ(
   site = "my1",
   year = 2022,
-  source = "aurn",
+  source = NULL,
   data_type = "hourly",
   pollutant = "all",
   hc = FALSE,
@@ -29,8 +29,10 @@ codes can be upper or lower case.}
 \item{year}{Year(s) to import. To import a series of years use, e.g.,
 \code{2000:2020}. To import several specific years use \code{year = c(2000, 2010, 2020)}.}
 
-\item{source}{The network to which the \code{site}(s) belong, defaulting to
-\code{"aurn"}. Providing a single network will attempt to import all of the
+\item{source}{The network to which the \code{site}(s) belong. The default, \code{NULL},
+allows \code{\link[=importUKAQ]{importUKAQ()}} to guess the correct \code{source}. When this isn't possible
+(for example, when the site code is ambiguous), users can provide a \code{source}.
+Providing a single network will attempt to import all of the
 given \code{site}s from the provided network. Alternatively, a vector of sources
 can be provided of the same length as \code{site} to indicate which network each
 \code{site} individually belongs. Available networks include:


### PR DESCRIPTION
This PR extends the capabilities introduced in #350.

In short, the default `source` in `importUKAQ()` is now `NULL`. This allows `importUKAQ()` to work out the `source` on its own, where possible.

See examples:

``` r
devtools::load_all()
#> ℹ Loading openair

set.seed(123)

meta_sample <-
  importMeta(year = 2023, source = "ukaq") |>
  dplyr::slice_sample(n = 1, by = source)

meta_sample$code
#> [1] "TALL"  "WL1"   "NL11"  "NPT4A" "BEL5"  "WA7"
meta_sample$source
#> [1] "aurn"  "aqe"   "saqn"  "waqn"  "ni"    "local"

aq <-
  importUKAQ(
    year = 2023,
    site = meta_sample$code
  )

dplyr::count(aq, source, site, code)
#> # A tibble: 5 × 4
#>   source site                            code      n
#>   <fct>  <chr>                           <chr> <int>
#> 1 aurn   Tallington                      TALL    504
#> 2 saqn   N Lanarkshire Kirkshaws         NL11   8760
#> 3 aqe    Waltham Forest Dawlish Rd       WL1    8760
#> 4 ni     Belfast Newtownards Road        BEL5   8760
#> 5 local  Wandsworth - Putney High Street WA7    8760
```

<sup>Created on 2024-08-12 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Caveats:

- Will error if the code is unknown.

- Will error if the code is ambiguous ("AD1").

``` r
devtools::load_all()
#> ℹ Loading openair

# ambiguous codes
importUKAQ(c("my1", "kc1", "ad1"))
#> Error in `guess_source()` at openair/R/importUKAQ.R:215:7:
#> ✖ Ambiguous site codes detected. Please specify source in
#>   `importUKAQ()`.
#> ℹ Ambiguous codes: AD1 (saqn, local)

# non existant codes
importUKAQ(c("my1", "kc1", "foo", "bar", "falk"))
#> Error in `guess_source()` at openair/R/importUKAQ.R:215:7:
#> ✖ Unknown site codes detected. Please ensure all site codes can be found
#>   in `importMeta()`.
#> ℹ Unknown site codes: FOO and BAR
```

<sup>Created on 2024-08-12 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

Ambiguous codes are few and far between, so it may just have to be an unfortunate feature of the function for those local to "AD1" for now! Unless you can think of a better treatment of them.