### PR TITLE
feat: add new colours, fixes, and error catching to `openColours()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 - add `calm.thresh` as an option to `windRose`. This change allows users to set a non-zero wind speed threshold that is considered as calm.
 
+- added new qualitative colour palettes to `openColours()`; the "tol" family are colour-blind friendly palettes based on the work of Paul Tol (<https://personal.sron.nl/~pault/>), and "tableau" and "observable" provide access to the "Tableau10" and "Observable10" palettes to aid in consistency with plots made in those platforms.
+
 ## Bug fixes
 
 - Fixed an issue wherein `importUKAQ()` would drop sites if importing from `local` sites *and* another network.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,12 @@
 
 - add `calm.thresh` as an option to `windRose`. This change allows users to set a non-zero wind speed threshold that is considered as calm.
 
-- added new qualitative colour palettes to `openColours()`; the "tol" family are colour-blind friendly palettes based on the work of Paul Tol (<https://personal.sron.nl/~pault/>), and "tableau" and "observable" provide access to the "Tableau10" and "Observable10" palettes to aid in consistency with plots made in those platforms.
+- Added new features for `openColours()`:
+
+    - Added new qualitative colour palettes: the "tol" family are colour-blind friendly palettes based on the work of Paul Tol (<https://personal.sron.nl/~pault/>), and "tableau" and "observable" provide access to the "Tableau10" and "Observable10" palettes to aid in consistency with plots made in those platforms.
+  
+    - When `n` isn't defined for a qualitative palette (e.g., "Dark2"), the full qualitative palette will be returned. Previously this errored with the default of `100`.
+  
 
 ## Bug fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
     - Added new qualitative colour palettes: the "tol" family are colour-blind friendly palettes based on the work of Paul Tol (<https://personal.sron.nl/~pault/>), and "tableau" and "observable" provide access to the "Tableau10" and "Observable10" palettes to aid in consistency with plots made in those platforms.
   
     - When `n` isn't defined for a qualitative palette (e.g., "Dark2"), the full qualitative palette will be returned. Previously this errored with the default of `100`.
+    
+    - `openColours()` will now check whether the provided `scheme` is either a known scheme name *or* a vector of valid R colours, and provide an informative error if this is not the case.
   
 
 ## Bug fixes

--- a/R/openColours.R
+++ b/R/openColours.R
@@ -224,7 +224,7 @@ openColours <- function(scheme = "default", n = 100) {
     if (any(!check)) {
       bad_cols <- unique(names(check[!check]))
       cli::cli_abort(
-        c("x" = "The following are not valid R colours nor {.fun openColours} palettes: {.field {bad_cols}}"),
+        c("x" = "The following are {.emph neither} valid R colours {.emph nor} {.fun openColours} palettes: {.field {bad_cols}}"),
         call = NULL
       )
     }

--- a/R/openColours.R
+++ b/R/openColours.R
@@ -216,10 +216,8 @@ openColours <- function(scheme = "default", n = 100) {
 
   # The palette with grey:
   cbPalette <- function(n) {
-    cols <- c(
-      "#999999", "#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2",
-      "#D55E00", "#CC79A7"
-    )
+    cols <- c("#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", 
+              "#CC79A7", "#999999", "#000000")
 
     if (n >= 1 && n < 9) {
       cols <- cols[1:n]

--- a/R/openColours.R
+++ b/R/openColours.R
@@ -103,292 +103,436 @@
 #' #  green to red:
 #' cols <- openColours(c("yellow", "green", "red"), 10)
 #' cols
-#' 
+#'
 openColours <- function(scheme = "default", n = 100) {
-  ## pre-defined brewer colour palletes sequential, diverging, qualitative
+  ## pre-defined brewer colour palettes sequential, diverging, qualitative
   brewer.col <- c(
-    "Blues", "BuGn", "BuPu", "GnBu", "Greens", "Greys", "Oranges", "OrRd", "PuBu",
-    "PuBuGn", "PuRd", "Purples", "RdPu", "Reds", "YlGn", "YlGnBu", "YlOrBr", "YlOrRd",
-    "BrBG", "PiYG", "PRGn", "PuOr", "RdBu", "RdGy", "RdYlBu", "RdYlGn", "Spectral",
-    "Accent", "Dark2", "Paired", "Pastel1", "Pastel2", "Set1", "Set2", "Set3"
+    "Blues",
+    "BuGn",
+    "BuPu",
+    "GnBu",
+    "Greens",
+    "Greys",
+    "Oranges",
+    "OrRd",
+    "PuBu",
+    "PuBuGn",
+    "PuRd",
+    "Purples",
+    "RdPu",
+    "Reds",
+    "YlGn",
+    "YlGnBu",
+    "YlOrBr",
+    "YlOrRd",
+    "BrBG",
+    "PiYG",
+    "PRGn",
+    "PuOr",
+    "RdBu",
+    "RdGy",
+    "RdYlBu",
+    "RdYlGn",
+    "Spectral",
+    "Accent",
+    "Dark2",
+    "Paired",
+    "Pastel1",
+    "Pastel2",
+    "Set1",
+    "Set2",
+    "Set3"
   )
+  
   ## max colours allowed
-
   brewer.n <- c(rep(9, 18), rep(9, 9), c(8, 8, 12, 9, 8, 9, 8, 12))
-
-  ## predefined schemes
-  schemes <- c(
-    "increment", "default", "brewer1", "heat", "jet", "hue",
-    "greyscale", brewer.col, "cbPalette", "okabeito", "viridis", "magma",
-    "inferno", "plasma", "cividis", "turbo", "daqi", "daqi.bands",
-    "gaf.cat", "gaf.seq", "gaf.focus", "tableau", "observable",
-    "tol", "tol.bright", "tol.muted", "tol.light"
+  
+  seq_schemes <-
+    c(
+      "increment",
+      "default",
+      "heat",
+      "jet",
+      "turbo",
+      "viridis",
+      "magma",
+      "inferno",
+      "plasma",
+      "cividis",
+      "gaf.seq"
+    )
+  
+  qual_schemes <- c(
+    "okabeito",
+    "cbPalette",
+    "daqi",
+    "daqi.bands",
+    "gaf.cat",
+    "gaf.focus",
+    "tableau",
+    "observable",
+    "tol",
+    "tol.bright",
+    "tol.muted",
+    "tol.light"
   )
-
-  ## schemes
-  heat <- colorRampPalette(brewer.pal(9, "YlOrRd"), interpolate = "spline")
-
-  viridis <- colorRampPalette(c(
-    "#440154FF", "#482878FF", "#3E4A89FF", "#31688EFF", "#26828EFF", "#1F9E89FF",
-    "#35B779FF", "#6DCD59FF", "#B4DE2CFF", "#FDE725FF"
-  ))
-
-  inferno <- colorRampPalette(c(
-    "#000004FF", "#1B0C42FF", "#4B0C6BFF", "#781C6DFF", "#A52C60FF", "#CF4446FF",
-    "#ED6925FF", "#FB9A06FF", "#F7D03CFF", "#FCFFA4FF"
-  ))
-
-  magma <- colorRampPalette(c(
-    "#000004FF", "#180F3EFF", "#451077FF", "#721F81FF", "#9F2F7FFF", "#CD4071FF",
-    "#F1605DFF", "#FD9567FF", "#FEC98DFF", "#FCFDBFFF"
-  ))
-
-  plasma <- colorRampPalette(c(
-    "#0D0887FF", "#47039FFF", "#7301A8FF", "#9C179EFF", "#BD3786FF", "#D8576BFF",
-    "#ED7953FF", "#FA9E3BFF", "#FDC926FF", "#F0F921FF"
-  ))
-
-  cividis <- colorRampPalette(c(
-    "#00204DFF", "#00336FFF", "#39486BFF", "#575C6DFF", "#707173FF", "#8A8779FF",
-    "#A69D75FF", "#C4B56CFF", "#E4CF5BFF", "#FFEA46FF"
-  ))
-
-
-  jet <- colorRampPalette(c(
-    "#00007F", "blue", "#007FFF", "cyan",
-    "#7FFF7F", "yellow", "#FF7F00", "red", "#7F0000"
-  ))
-
-  turbo <- colorRampPalette(c(
-    "#30123BFF", "#4662D7FF", "#36AAF9FF", "#1AE4B6FF", "#72FE5EFF",
-    "#C7EF34FF", "#FABA39FF", "#F66B19FF", "#CB2A04FF", "#7A0403FF"
-  ))
-
-  gaf_ramp <- colorRampPalette(c(
-    "#12436D", "#2073BC", "#6BACE6"
-  ))
-
-  default.col <- colorRampPalette(brewer.pal(11, "Spectral"), interpolate = "spline")
-
-  ## for this palette use specified number if possible - because it has been thought about...
-  brewer1 <- function(n) {
-    if (n >= 3 & n <= 9) {
-      brewer.pal(n, "Set1")
-    } else {
-      thefun <- suppressWarnings(colorRampPalette(brewer.pal(9, "Set1"), interpolate = "spline"))
-      thefun(n)
-    }
-  }
-
-  ## for this palette use specified number if possible - because it has been thought about...
-  find.brewer <- function(thecol, n) {
-    n.brew <- brewer.n[scheme == brewer.col]
-
-    if (n >= 3 & n <= n.brew) {
-      brewer.pal(n, thecol)
-    } else {
-      thefun <- suppressWarnings(colorRampPalette(brewer.pal(n.brew, thecol), interpolate = "spline"))
-      thefun(n)
-    }
-  }
-
-  increment <- colorRampPalette(c(
-    "#B0FFF1", "#9CFFC7", "#87FF8E", "#A0FF73",
-    "#B4FF69", "#CCFF60", "#E7FF56", "#FFF84D", "#FFCB46", "#FF9C40",
-    "#FF6939", "#FF3333", "#CC1B62", "#990A7C", "#520066"
-  ))
-
-  h <- c(0, 360) + 15
-  l <- 65
-  c <- 100
-
-  if ((diff(h) %% 360) < 1) {
-    h[2] <- h[2] - 360 / n
-  }
-
-  hue <- grDevices::hcl(
-    h = seq(h[1], h[2], length = n),
-    c = c,
-    l = l
-  )
-
-  greyscale <- grey(seq(0.9, 0.1, length = n))
-
-  # The palette with grey:
-  cbPalette <- function(n) {
-    cols <- c("#E69F00", "#56B4E9", "#009E73", "#F0E442", "#0072B2", "#D55E00", 
-              "#CC79A7", "#999999", "#000000")
-
-    if (n >= 1 && n < 9) {
-      cols <- cols[1:n]
-    } else {
-      cli::cli_abort(
-        c(
-          "!" = "Too many colours selected for {.code {scheme}}.",
-          "i" = "{.code n} should be between 1 and 8."
-        ),
-        call = NULL
-      )
-    }
-  }
-
-  # Defra's DAQI Colours
-  daqi_pal <- function(n, extent) {
-    if (extent == "i") {
-      cols <- c(
-        "#9CFF9C", "#31FF00", "#31CF00", "#FFFF00", "#FFCF00",
-        "#FF9A00", "#FF6464", "#FF0000", "#990000", "#CE30FF"
-      )
-      max <- 10
-    } else if (extent == "b") {
-      cols <- c("#009900", "#ff9900", "#ff0000", "#990099")
-      max <- 4
-    }
-
-    if (n >= 1 && n <= max) {
-      cols <- cols[1:n]
-    } else {
-      cli::cli_abort(
-        c(
-          "!" = "Too many colours selected for {.code {scheme}}.",
-          "i" = "{.code n} should be between 1 and {max}."
-        ),
-        call = NULL
-      )
-    }
-  }
-
-  gaf_pal <- function(n, extent) {
-    if (extent == "c") {
-      cols <- c("#12436D", "#28A197", "#801650", "#F46A25", "#3D3D3D", "#A285D1")
-      max <- 6
-    } else if (extent == "f") {
-      cols <- c("#BFBFBF", "#12436D")
-      max <- 2
-    }
-
-    if (n >= 1 && n <= max) {
-      cols <- cols[1:n]
-    } else {
-      cli::cli_abort(
-        c(
-          "!" = "Too many colours selected for {.code {scheme}}.",
-          "i" = "{.code n} should be between 1 and {max}."
-        ),
-        call = NULL
-      )
-    }
-  }
   
-  # from Paul Tol <https://personal.sron.nl/~pault/>
-  tol_pal <- function(n, extent = c("bright", "muted", "light")) {
-    if (extent == "bright") {
-      cols <- c('#EE6677', '#228833', '#4477AA', '#CCBB44', '#66CCEE', '#AA3377', '#BBBBBB') 
-    }
-    if (extent == "muted") {
-      cols <- c('#88CCEE', '#44AA99', '#117733', '#332288', '#DDCC77', '#999933','#CC6677', '#882255', '#AA4499', '#DDDDDD')
-    }
-    if (extent == "light") {
-      cols <- c('#BBCC33', '#AAAA00', '#77AADD', '#EE8866', '#EEDD88', '#FFAABB', '#99DDFF', '#44BB99', '#DDDDDD')
-    }
-    
-    max <- length(cols)
-    
-    if (n >= 1 && n <= max) {
-      cols <- cols[1:n]
-      return(cols)
-    } else {
-      cli::cli_abort(
-        c("!" = "Too many colours selected for {.code {scheme}}.",
-          "i" = "{.code n} should be between 1 and {max}."),
-        call = NULL
-      )
-    }
-  }
+  ## all schemes
+  schemes <- c(seq_schemes,
+               qual_schemes,
+               "brewer1",
+               "hue",
+               "greyscale",
+               brewer.col)
   
-  borrowed_pal <- function(n, pal = "tableau") {
-    if (pal == "tableau") {
-      cols <- c(
-        "#5778a4",
-        "#e49444",
-        "#d1615d",
-        "#85b6b2",
-        "#6a9f58",
-        "#e7ca60",
-        "#a87c9f",
-        "#f1a2a9",
-        "#967662",
-        "#b8b0ac"
-      )
-    }
-    if (pal == "observable") {
-      cols <- c(
-        "#4269D0",
-        "#EFB118",
-        "#FF725C",
-        "#6CC5B0",
-        "#3CA951",
-        "#FF8AB7",
-        "#A463F2",
-        "#97BBF5",
-        "#9C6B4E",
-        "#9498A0"
-      )
-    }
-    
-    max <- length(cols)
-    
-    if (n >= 1 && n <= max) {
-      cols <- cols[1:n]
-      return(cols)
-    } else {
-      cli::cli_abort(
-        c("!" = "Too many colours selected for {.code {scheme}}.",
-          "i" = "{.code n} should be between 1 and {max}."),
-        call = NULL
-      )
-    }
-  }
-  
-
   ## error catcher
   if (length(scheme) == 1) {
-    if (scheme %in% brewer.col) cols <- find.brewer(scheme, n)
-    if (scheme == "increment") cols <- increment(n)
-    if (scheme == "default") cols <- rev(default.col(n))
-    if (scheme == "brewer1") cols <- brewer1(n)
-    if (scheme %in% brewer.col) cols <- find.brewer(scheme, n)
-    if (scheme == "heat") cols <- heat(n)
-    if (scheme == "jet") cols <- jet(n)
-    if (scheme == "turbo") cols <- turbo(n)
-    if (scheme == "viridis") cols <- viridis(n)
-    if (scheme == "magma") cols <- magma(n)
-    if (scheme == "inferno") cols <- inferno(n)
-    if (scheme == "plasma") cols <- plasma(n)
-    if (scheme == "cividis") cols <- cividis(n)
-    if (scheme == "hue") cols <- hue
-    if (scheme == "greyscale") cols <- greyscale
-    if (scheme %in% c("okabeito", "cbPalette")) cols <- cbPalette(n)
-    if (scheme == "daqi") cols <- daqi_pal(n, extent = "i")
-    if (scheme == "daqi.bands") cols <- daqi_pal(n, extent = "b")
-    if (scheme == "gaf.cat") cols <- gaf_pal(n, extent = "c")
-    if (scheme == "gaf.focus") cols <- gaf_pal(n, extent = "f")
-    if (scheme == "gaf.seq") cols <- gaf_ramp(n)
-    if (scheme == "tableau") cols <- borrowed_pal(n, "tableau")
-    if (scheme == "observable") cols <- borrowed_pal(n, "observable")
-    if (scheme %in% c("tol", "tol.bright")) cols <- tol_pal(n, "bright")
-    if (scheme == "tol.muted") cols <- tol_pal(n, "muted")
-    if (scheme == "tol.light") cols <- tol_pal(n, "light")
+    if (scheme == "brewer1") {
+      cols <- brewerPalette(n, "Set1")
+    }
+    if (scheme %in% brewer.col) {
+      cols <- brewerPalette(n, scheme)
+    }
+    if (scheme == "hue") {
+      cols <- huePalette(n)
+    }
+    if (scheme == "greyscale") {
+      cols <- grey(seq(0.9, 0.1, length = n))
+    }
+    if (scheme %in% seq_schemes) {
+      cols <- seqPalette(n, scheme = scheme)
+    }
+    if (scheme %in% qual_schemes) {
+      cols <- qualPalette(n, scheme = scheme)
+    }
   }
-
-  if (!any(scheme %in% schemes)) { # assume user has given own colours
-    if (length(scheme) > 1) { ## interpolate
+  
+  if (!any(scheme %in% schemes)) {
+    # assume user has given own colours
+    if (length(scheme) > 1) {
+      ## interpolate
       user.cols <- colorRampPalette(scheme)
       cols <- user.cols(n)
     } else {
       cols <- rep(scheme, n)
     }
   }
-
+  
   cols
+}
+
+#' Function to build Brewer palettes
+#' @noRd
+brewerPalette <- function(n, scheme) {
+  n.brew <- brewer.n[scheme == brewer.col]
+  
+  if (n >= 3 & n <= n.brew) {
+    brewer.pal(n, scheme)
+  } else {
+    thefun <-
+      suppressWarnings(colorRampPalette(brewer.pal(n.brew, scheme), interpolate = "spline"))
+    thefun(n)
+  }
+}
+
+#' Build hue palette
+#' @noRd
+huePalette <- function(n) {
+  h <- c(0, 360) + 15
+  l <- 65
+  c <- 100
+  
+  if ((diff(h) %% 360) < 1) {
+    h[2] <- h[2] - 360 / n
+  }
+  
+  grDevices::hcl(h = seq(h[1], h[2], length = n),
+                 c = c,
+                 l = l)
+}
+
+#' Function to manage qualitative palettes
+#' @noRd
+qualPalette <- function(n, scheme) {
+  if (scheme %in% c("cbPalette", "okabeito")) {
+    cols <- c(
+      "#E69F00",
+      "#56B4E9",
+      "#009E73",
+      "#F0E442",
+      "#0072B2",
+      "#D55E00",
+      "#CC79A7",
+      "#999999",
+      "#000000"
+    )
+  }
+  
+  if (scheme %in% c("daqi")) {
+    cols <- c(
+      "#9CFF9C",
+      "#31FF00",
+      "#31CF00",
+      "#FFFF00",
+      "#FFCF00",
+      "#FF9A00",
+      "#FF6464",
+      "#FF0000",
+      "#990000",
+      "#CE30FF"
+    )
+  }
+  
+  if (scheme %in% c("daqi.bands")) {
+    cols <- c("#009900", "#ff9900", "#ff0000", "#990099")
+  }
+  
+  if (scheme %in% c("gaf.cat")) {
+    cols <-
+      c("#12436D",
+        "#28A197",
+        "#801650",
+        "#F46A25",
+        "#3D3D3D",
+        "#A285D1")
+  }
+  
+  if (scheme %in% c("gaf.focus")) {
+    cols <- c("#BFBFBF", "#12436D")
+  }
+  
+  if (scheme %in% c("tol", "tol.bright")) {
+    cols <-
+      c("#EE6677",
+        "#228833",
+        "#4477AA",
+        "#CCBB44",
+        "#66CCEE",
+        "#AA3377",
+        "#BBBBBB")
+  }
+  
+  if (scheme == "tol.muted") {
+    cols <-
+      c(
+        "#88CCEE",
+        "#44AA99",
+        "#117733",
+        "#332288",
+        "#DDCC77",
+        "#999933",
+        "#CC6677",
+        "#882255",
+        "#AA4499",
+        "#DDDDDD"
+      )
+  }
+  
+  if (scheme == "tol.light") {
+    cols <-
+      c(
+        "#BBCC33",
+        "#AAAA00",
+        "#77AADD",
+        "#EE8866",
+        "#EEDD88",
+        "#FFAABB",
+        "#99DDFF",
+        "#44BB99",
+        "#DDDDDD"
+      )
+  }
+  
+  if (scheme == "tableau") {
+    cols <- c(
+      "#5778a4",
+      "#e49444",
+      "#d1615d",
+      "#85b6b2",
+      "#6a9f58",
+      "#e7ca60",
+      "#a87c9f",
+      "#f1a2a9",
+      "#967662",
+      "#b8b0ac"
+    )
+  }
+  
+  if (scheme == "observable") {
+    cols <- c(
+      "#4269D0",
+      "#EFB118",
+      "#FF725C",
+      "#6CC5B0",
+      "#3CA951",
+      "#FF8AB7",
+      "#A463F2",
+      "#97BBF5",
+      "#9C6B4E",
+      "#9498A0"
+    )
+  }
+  
+  max <- length(cols)
+  
+  if (n >= 1 && n <= max) {
+    cols <- cols[1:n]
+  } else {
+    cli::cli_abort(
+      c("!" = "Too many colours selected for {.code {scheme}}.",
+        "i" = "{.code n} should be between 1 and {max}."),
+      call = NULL
+    )
+  }
+}
+
+
+#' Function to manage sequential palettes
+#' @noRd
+seqPalette <- function(n, scheme) {
+  interpolate <- "linear"
+  
+  if (scheme == "default") {
+    cols <- rev(brewer.pal(11, "Spectral"))
+    interpolate <- "spline"
+  }
+  
+  if (scheme == "increment") {
+    cols <- c(
+      "#B0FFF1",
+      "#9CFFC7",
+      "#87FF8E",
+      "#A0FF73",
+      "#B4FF69",
+      "#CCFF60",
+      "#E7FF56",
+      "#FFF84D",
+      "#FFCB46",
+      "#FF9C40",
+      "#FF6939",
+      "#FF3333",
+      "#CC1B62",
+      "#990A7C",
+      "#520066"
+    )
+  }
+  
+  if (scheme == "heat") {
+    cols <- brewer.pal(9, "YlOrRd")
+    interpolate <- "spline"
+  }
+  
+  if (scheme == "viridis") {
+    cols <- c(
+      "#440154FF",
+      "#482878FF",
+      "#3E4A89FF",
+      "#31688EFF",
+      "#26828EFF",
+      "#1F9E89FF",
+      "#35B779FF",
+      "#6DCD59FF",
+      "#B4DE2CFF",
+      "#FDE725FF"
+    )
+  }
+  
+  if (scheme == "inferno") {
+    cols <- c(
+      "#000004FF",
+      "#1B0C42FF",
+      "#4B0C6BFF",
+      "#781C6DFF",
+      "#A52C60FF",
+      "#CF4446FF",
+      "#ED6925FF",
+      "#FB9A06FF",
+      "#F7D03CFF",
+      "#FCFFA4FF"
+    )
+  }
+  
+  if (scheme == "magma") {
+    cols <- c(
+      "#000004FF",
+      "#180F3EFF",
+      "#451077FF",
+      "#721F81FF",
+      "#9F2F7FFF",
+      "#CD4071FF",
+      "#F1605DFF",
+      "#FD9567FF",
+      "#FEC98DFF",
+      "#FCFDBFFF"
+    )
+  }
+  
+  if (scheme == "plasma") {
+    cols <- c(
+      "#0D0887FF",
+      "#47039FFF",
+      "#7301A8FF",
+      "#9C179EFF",
+      "#BD3786FF",
+      "#D8576BFF",
+      "#ED7953FF",
+      "#FA9E3BFF",
+      "#FDC926FF",
+      "#F0F921FF"
+    )
+  }
+  
+  if (scheme == "cividis") {
+    cols <- c(
+      "#00204DFF",
+      "#00336FFF",
+      "#39486BFF",
+      "#575C6DFF",
+      "#707173FF",
+      "#8A8779FF",
+      "#A69D75FF",
+      "#C4B56CFF",
+      "#E4CF5BFF",
+      "#FFEA46FF"
+    )
+  }
+  
+  if (scheme == "jet") {
+    cols <- c(
+      "#00007F",
+      "#0000FF",
+      "#007FFF",
+      "#00FFFF",
+      "#7FFF7F",
+      "#FFFF00",
+      "#FF7F00",
+      "#FF0000",
+      "#7F0000"
+    )
+  }
+  
+  if (scheme == "turbo") {
+    cols <- c(
+      "#30123BFF",
+      "#4662D7FF",
+      "#36AAF9FF",
+      "#1AE4B6FF",
+      "#72FE5EFF",
+      "#C7EF34FF",
+      "#FABA39FF",
+      "#F66B19FF",
+      "#CB2A04FF",
+      "#7A0403FF"
+    )
+  }
+  
+  if (scheme == "gaf.seq") {
+    cols <- c("#12436D", "#2073BC", "#6BACE6")
+  }
+  
+  fun <- colorRampPalette(colors = cols, interpolate = interpolate)
+  
+  cols <- fun(n)
+  
+  return(cols)
 }

--- a/R/openColours.R
+++ b/R/openColours.R
@@ -30,8 +30,18 @@
 #'   * Simplified versions of the `RColorBrewer` qualitative palettes:
 #'   "Accent", "Dark2", "Paired", "Pastel1", "Pastel2", "Set1", "Set2", "Set3".
 #'
-#'   * "cbPalette", a colour-blind safe palette based on the work of
-#'   <https://www.nature.com/articles/nmeth.1618>
+#'   * "okabeito" (or "cbPalette"), a colour-blind safe palette based on
+#'   the work of Masataka Okabe and Kei Ito (<https://jfly.uni-koeln.de/color/>)
+#'
+#'   * "tol.bright" (or "tol"), "tol.muted" and "tol.light", colour-blind safe
+#'   palettes based on the work of Paul Tol (<https://personal.sron.nl/~pault/>)
+#'
+#'   * "tableau" and "observable", aliases for the
+#'   "Tableau10"
+#'   (<https://www.tableau.com/blog/colors-upgrade-tableau-10-56782>) and
+#'   "Observable10" (<https://observablehq.com/blog/crafting-data-colors>)
+#'   colour palettes. These could be useful for consistency between openair
+#'   plots and with figures made in Tableau or Observable Plot.
 #'
 #'   **UK Government Palettes:**
 #'
@@ -81,7 +91,8 @@
 #' @author Jack Davison
 #' @references \url{https://colorbrewer2.org/}
 #' @references \url{https://uk-air.defra.gov.uk/air-pollution/daqi}
-#' @references \url{https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/}
+#' @references
+#' \url{https://analysisfunction.civilservice.gov.uk/policy-store/data-visualisation-colours-in-charts/}
 #' @examples
 #'
 #' # to return 5 colours from the "jet" scheme:
@@ -92,7 +103,7 @@
 #' #  green to red:
 #' cols <- openColours(c("yellow", "green", "red"), 10)
 #' cols
-#'
+#' 
 openColours <- function(scheme = "default", n = 100) {
   ## pre-defined brewer colour palletes sequential, diverging, qualitative
   brewer.col <- c(
@@ -108,9 +119,10 @@ openColours <- function(scheme = "default", n = 100) {
   ## predefined schemes
   schemes <- c(
     "increment", "default", "brewer1", "heat", "jet", "hue",
-    "greyscale", brewer.col, "cbPalette", "viridis", "magma",
+    "greyscale", brewer.col, "cbPalette", "okabeito", "viridis", "magma",
     "inferno", "plasma", "cividis", "turbo", "daqi", "daqi.bands",
-    "gaf.cat", "gaf.seq", "gaf.focus"
+    "gaf.cat", "gaf.seq", "gaf.focus", "tableau", "observable",
+    "tol", "tol.bright", "tol.muted", "tol.light"
   )
 
   ## schemes
@@ -158,7 +170,7 @@ openColours <- function(scheme = "default", n = 100) {
 
   default.col <- colorRampPalette(brewer.pal(11, "Spectral"), interpolate = "spline")
 
-  ## for this pallete use specfified number if possible - because it has been thought about...
+  ## for this palette use specified number if possible - because it has been thought about...
   brewer1 <- function(n) {
     if (n >= 3 & n <= 9) {
       brewer.pal(n, "Set1")
@@ -168,7 +180,7 @@ openColours <- function(scheme = "default", n = 100) {
     }
   }
 
-  ## for this pallete use specfified number if possible - because it has been thought about...
+  ## for this palette use specified number if possible - because it has been thought about...
   find.brewer <- function(thecol, n) {
     n.brew <- brewer.n[scheme == brewer.col]
 
@@ -269,7 +281,77 @@ openColours <- function(scheme = "default", n = 100) {
       )
     }
   }
-
+  
+  # from Paul Tol <https://personal.sron.nl/~pault/>
+  tol_pal <- function(n, extent = c("bright", "muted", "light")) {
+    if (extent == "bright") {
+      cols <- c('#EE6677', '#228833', '#4477AA', '#CCBB44', '#66CCEE', '#AA3377', '#BBBBBB') 
+    }
+    if (extent == "muted") {
+      cols <- c('#88CCEE', '#44AA99', '#117733', '#332288', '#DDCC77', '#999933','#CC6677', '#882255', '#AA4499', '#DDDDDD')
+    }
+    if (extent == "light") {
+      cols <- c('#BBCC33', '#AAAA00', '#77AADD', '#EE8866', '#EEDD88', '#FFAABB', '#99DDFF', '#44BB99', '#DDDDDD')
+    }
+    
+    max <- length(cols)
+    
+    if (n >= 1 && n <= max) {
+      cols <- cols[1:n]
+      return(cols)
+    } else {
+      cli::cli_abort(
+        c("!" = "Too many colours selected for {.code {scheme}}.",
+          "i" = "{.code n} should be between 1 and {max}."),
+        call = NULL
+      )
+    }
+  }
+  
+  borrowed_pal <- function(n, pal = "tableau") {
+    if (pal == "tableau") {
+      cols <- c(
+        "#5778a4",
+        "#e49444",
+        "#d1615d",
+        "#85b6b2",
+        "#6a9f58",
+        "#e7ca60",
+        "#a87c9f",
+        "#f1a2a9",
+        "#967662",
+        "#b8b0ac"
+      )
+    }
+    if (pal == "observable") {
+      cols <- c(
+        "#4269D0",
+        "#EFB118",
+        "#FF725C",
+        "#6CC5B0",
+        "#3CA951",
+        "#FF8AB7",
+        "#A463F2",
+        "#97BBF5",
+        "#9C6B4E",
+        "#9498A0"
+      )
+    }
+    
+    max <- length(cols)
+    
+    if (n >= 1 && n <= max) {
+      cols <- cols[1:n]
+      return(cols)
+    } else {
+      cli::cli_abort(
+        c("!" = "Too many colours selected for {.code {scheme}}.",
+          "i" = "{.code n} should be between 1 and {max}."),
+        call = NULL
+      )
+    }
+  }
+  
 
   ## error catcher
   if (length(scheme) == 1) {
@@ -288,12 +370,17 @@ openColours <- function(scheme = "default", n = 100) {
     if (scheme == "cividis") cols <- cividis(n)
     if (scheme == "hue") cols <- hue
     if (scheme == "greyscale") cols <- greyscale
-    if (scheme == "cbPalette") cols <- cbPalette(n)
+    if (scheme %in% c("okabeito", "cbPalette")) cols <- cbPalette(n)
     if (scheme == "daqi") cols <- daqi_pal(n, extent = "i")
     if (scheme == "daqi.bands") cols <- daqi_pal(n, extent = "b")
     if (scheme == "gaf.cat") cols <- gaf_pal(n, extent = "c")
     if (scheme == "gaf.focus") cols <- gaf_pal(n, extent = "f")
     if (scheme == "gaf.seq") cols <- gaf_ramp(n)
+    if (scheme == "tableau") cols <- borrowed_pal(n, "tableau")
+    if (scheme == "observable") cols <- borrowed_pal(n, "observable")
+    if (scheme %in% c("tol", "tol.bright")) cols <- tol_pal(n, "bright")
+    if (scheme == "tol.muted") cols <- tol_pal(n, "muted")
+    if (scheme == "tol.light") cols <- tol_pal(n, "light")
   }
 
   if (!any(scheme %in% schemes)) { # assume user has given own colours

--- a/R/openColours.R
+++ b/R/openColours.R
@@ -105,7 +105,7 @@
 #' cols
 #'
 openColours <- function(scheme = "default", n = 100) {
-  ## pre-defined brewer colour palettes sequential, diverging, qualitative
+  # pre-defined brewer colour palettes sequential, diverging, qualitative
   brewer.col <- c(
     "Blues",
     "BuGn",
@@ -144,9 +144,10 @@ openColours <- function(scheme = "default", n = 100) {
     "Set3"
   )
   
-  ## max colours allowed
+  # max colours allowed for each brewer pal
   brewer.n <- c(rep(9, 18), rep(9, 9), c(8, 8, 12, 9, 8, 9, 8, 12))
   
+  # sequential palettes
   seq_schemes <-
     c(
       "increment",
@@ -162,22 +163,26 @@ openColours <- function(scheme = "default", n = 100) {
       "gaf.seq"
     )
   
-  qual_schemes <- c(
-    "okabeito",
-    "cbPalette",
-    "daqi",
-    "daqi.bands",
-    "gaf.cat",
-    "gaf.focus",
-    "tableau",
-    "observable",
-    "tol",
-    "tol.bright",
-    "tol.muted",
-    "tol.light"
+  # qualitative palettes and maximum lengths
+  qual_scheme_lengths <- c(
+    "okabeito" = 9,
+    "cbPalette" = 9,
+    "daqi" = 10,
+    "daqi.bands" = 4,
+    "gaf.cat" = 6,
+    "gaf.focus" = 2,
+    "tableau" = 10,
+    "observable" = 10,
+    "tol" = 7,
+    "tol.bright" = 7,
+    "tol.muted" = 10,
+    "tol.light" = 9
   )
   
-  ## all schemes
+  # names of qualitative palettes
+  qual_schemes <- names(qual_scheme_lengths)
+  
+  # combine all schemes into vector
   schemes <- c(seq_schemes,
                qual_schemes,
                "brewer1",
@@ -185,7 +190,7 @@ openColours <- function(scheme = "default", n = 100) {
                "greyscale",
                brewer.col)
   
-  ## error catcher
+  # get colours based on scheme
   if (length(scheme) == 1) {
     if (scheme == "brewer1") {
       cols <- brewerPalette(n, "Set1")
@@ -203,14 +208,18 @@ openColours <- function(scheme = "default", n = 100) {
       cols <- seqPalette(n, scheme = scheme)
     }
     if (scheme %in% qual_schemes) {
+      # if n not provided, return max number o
+      if (missing(n)) {
+        n <- qual_scheme_lengths[[scheme]]
+      }
       cols <- qualPalette(n, scheme = scheme)
     }
   }
   
+  # if scheme isn't a scheme name, assume user has given own colours
   if (!any(scheme %in% schemes)) {
-    # assume user has given own colours
     if (length(scheme) > 1) {
-      ## interpolate
+      # interpolate
       user.cols <- colorRampPalette(scheme)
       cols <- user.cols(n)
     } else {

--- a/R/openColours.R
+++ b/R/openColours.R
@@ -143,10 +143,10 @@ openColours <- function(scheme = "default", n = 100) {
     "Set2",
     "Set3"
   )
-  
+
   # max colours allowed for each brewer pal
   brewer.n <- c(rep(9, 18), rep(9, 9), c(8, 8, 12, 9, 8, 9, 8, 12))
-  
+
   # sequential palettes
   seq_schemes <-
     c(
@@ -162,7 +162,7 @@ openColours <- function(scheme = "default", n = 100) {
       "cividis",
       "gaf.seq"
     )
-  
+
   # qualitative palettes and maximum lengths
   qual_scheme_lengths <- c(
     "okabeito" = 9,
@@ -178,25 +178,27 @@ openColours <- function(scheme = "default", n = 100) {
     "tol.muted" = 10,
     "tol.light" = 9
   )
-  
+
   # names of qualitative palettes
   qual_schemes <- names(qual_scheme_lengths)
-  
+
   # combine all schemes into vector
-  schemes <- c(seq_schemes,
-               qual_schemes,
-               "brewer1",
-               "hue",
-               "greyscale",
-               brewer.col)
-  
+  schemes <- c(
+    seq_schemes,
+    qual_schemes,
+    "brewer1",
+    "hue",
+    "greyscale",
+    brewer.col
+  )
+
   # get colours based on scheme
-  if (length(scheme) == 1) {
+  if (length(scheme) == 1L) {
     if (scheme == "brewer1") {
-      cols <- brewerPalette(n, "Set1")
+      cols <- brewerPalette(n, "Set1", brewer.col, brewer.n)
     }
     if (scheme %in% brewer.col) {
-      cols <- brewerPalette(n, scheme)
+      cols <- brewerPalette(n, scheme, brewer.col, brewer.n)
     }
     if (scheme == "hue") {
       cols <- huePalette(n)
@@ -215,9 +217,18 @@ openColours <- function(scheme = "default", n = 100) {
       cols <- qualPalette(n, scheme = scheme)
     }
   }
-  
+
   # if scheme isn't a scheme name, assume user has given own colours
   if (!any(scheme %in% schemes)) {
+    check <- areColors(scheme)
+    if (any(!check)) {
+      bad_cols <- unique(names(check[!check]))
+      cli::cli_abort(
+        c("x" = "The following are not valid R colours nor {.fun openColours} palettes: {.field {bad_cols}}"),
+        call = NULL
+      )
+    }
+
     if (length(scheme) > 1) {
       # interpolate
       user.cols <- colorRampPalette(scheme)
@@ -226,15 +237,25 @@ openColours <- function(scheme = "default", n = 100) {
       cols <- rep(scheme, n)
     }
   }
-  
+
+  if (any(scheme %in% schemes) & length(scheme) > 1L) {
+    cli::cli_abort(
+      c(
+        "x" = "Please provide {.strong either} 1 {.fun openColours} palette {.emph or} a vector of valid R colours",
+        "i" = "See {.code ?openColours} for a list of palettes."
+      ),
+      call = NULL
+    )
+  }
+
   cols
 }
 
 #' Function to build Brewer palettes
 #' @noRd
-brewerPalette <- function(n, scheme) {
+brewerPalette <- function(n, scheme, brewer.col, brewer.n) {
   n.brew <- brewer.n[scheme == brewer.col]
-  
+
   if (n >= 3 & n <= n.brew) {
     brewer.pal(n, scheme)
   } else {
@@ -250,14 +271,16 @@ huePalette <- function(n) {
   h <- c(0, 360) + 15
   l <- 65
   c <- 100
-  
+
   if ((diff(h) %% 360) < 1) {
     h[2] <- h[2] - 360 / n
   }
-  
-  grDevices::hcl(h = seq(h[1], h[2], length = n),
-                 c = c,
-                 l = l)
+
+  grDevices::hcl(
+    h = seq(h[1], h[2], length = n),
+    c = c,
+    l = l
+  )
 }
 
 #' Function to manage qualitative palettes
@@ -276,7 +299,7 @@ qualPalette <- function(n, scheme) {
       "#000000"
     )
   }
-  
+
   if (scheme %in% c("daqi")) {
     cols <- c(
       "#9CFF9C",
@@ -291,36 +314,40 @@ qualPalette <- function(n, scheme) {
       "#CE30FF"
     )
   }
-  
+
   if (scheme %in% c("daqi.bands")) {
     cols <- c("#009900", "#ff9900", "#ff0000", "#990099")
   }
-  
+
   if (scheme %in% c("gaf.cat")) {
     cols <-
-      c("#12436D",
+      c(
+        "#12436D",
         "#28A197",
         "#801650",
         "#F46A25",
         "#3D3D3D",
-        "#A285D1")
+        "#A285D1"
+      )
   }
-  
+
   if (scheme %in% c("gaf.focus")) {
     cols <- c("#BFBFBF", "#12436D")
   }
-  
+
   if (scheme %in% c("tol", "tol.bright")) {
     cols <-
-      c("#EE6677",
+      c(
+        "#EE6677",
         "#228833",
         "#4477AA",
         "#CCBB44",
         "#66CCEE",
         "#AA3377",
-        "#BBBBBB")
+        "#BBBBBB"
+      )
   }
-  
+
   if (scheme == "tol.muted") {
     cols <-
       c(
@@ -336,7 +363,7 @@ qualPalette <- function(n, scheme) {
         "#DDDDDD"
       )
   }
-  
+
   if (scheme == "tol.light") {
     cols <-
       c(
@@ -351,7 +378,7 @@ qualPalette <- function(n, scheme) {
         "#DDDDDD"
       )
   }
-  
+
   if (scheme == "tableau") {
     cols <- c(
       "#5778a4",
@@ -366,7 +393,7 @@ qualPalette <- function(n, scheme) {
       "#b8b0ac"
     )
   }
-  
+
   if (scheme == "observable") {
     cols <- c(
       "#4269D0",
@@ -381,15 +408,17 @@ qualPalette <- function(n, scheme) {
       "#9498A0"
     )
   }
-  
+
   max <- length(cols)
-  
+
   if (n >= 1 && n <= max) {
     cols <- cols[1:n]
   } else {
     cli::cli_abort(
-      c("!" = "Too many colours selected for {.code {scheme}}.",
-        "i" = "{.code n} should be between 1 and {max}."),
+      c(
+        "!" = "Too many colours selected for {.code {scheme}}.",
+        "i" = "{.code n} should be between 1 and {max}."
+      ),
       call = NULL
     )
   }
@@ -400,12 +429,12 @@ qualPalette <- function(n, scheme) {
 #' @noRd
 seqPalette <- function(n, scheme) {
   interpolate <- "linear"
-  
+
   if (scheme == "default") {
     cols <- rev(brewer.pal(11, "Spectral"))
     interpolate <- "spline"
   }
-  
+
   if (scheme == "increment") {
     cols <- c(
       "#B0FFF1",
@@ -425,12 +454,12 @@ seqPalette <- function(n, scheme) {
       "#520066"
     )
   }
-  
+
   if (scheme == "heat") {
     cols <- brewer.pal(9, "YlOrRd")
     interpolate <- "spline"
   }
-  
+
   if (scheme == "viridis") {
     cols <- c(
       "#440154FF",
@@ -445,7 +474,7 @@ seqPalette <- function(n, scheme) {
       "#FDE725FF"
     )
   }
-  
+
   if (scheme == "inferno") {
     cols <- c(
       "#000004FF",
@@ -460,7 +489,7 @@ seqPalette <- function(n, scheme) {
       "#FCFFA4FF"
     )
   }
-  
+
   if (scheme == "magma") {
     cols <- c(
       "#000004FF",
@@ -475,7 +504,7 @@ seqPalette <- function(n, scheme) {
       "#FCFDBFFF"
     )
   }
-  
+
   if (scheme == "plasma") {
     cols <- c(
       "#0D0887FF",
@@ -490,7 +519,7 @@ seqPalette <- function(n, scheme) {
       "#F0F921FF"
     )
   }
-  
+
   if (scheme == "cividis") {
     cols <- c(
       "#00204DFF",
@@ -505,7 +534,7 @@ seqPalette <- function(n, scheme) {
       "#FFEA46FF"
     )
   }
-  
+
   if (scheme == "jet") {
     cols <- c(
       "#00007F",
@@ -519,7 +548,7 @@ seqPalette <- function(n, scheme) {
       "#7F0000"
     )
   }
-  
+
   if (scheme == "turbo") {
     cols <- c(
       "#30123BFF",
@@ -534,14 +563,27 @@ seqPalette <- function(n, scheme) {
       "#7A0403FF"
     )
   }
-  
+
   if (scheme == "gaf.seq") {
     cols <- c("#12436D", "#2073BC", "#6BACE6")
   }
-  
+
   fun <- colorRampPalette(colors = cols, interpolate = interpolate)
-  
+
   cols <- fun(n)
-  
+
   return(cols)
+}
+
+#' Helper to check provided data are valid colours
+#' @noRd
+areColors <- function(x) {
+  sapply(x, function(X) {
+    tryCatch(
+      is.matrix(col2rgb(X)),
+      error = function(e) {
+        FALSE
+      }
+    )
+  })
 }

--- a/man/openColours.Rd
+++ b/man/openColours.Rd
@@ -46,8 +46,16 @@ The following schemes are made available by \code{openColours()}:
 \itemize{
 \item Simplified versions of the \code{RColorBrewer} qualitative palettes:
 "Accent", "Dark2", "Paired", "Pastel1", "Pastel2", "Set1", "Set2", "Set3".
-\item "cbPalette", a colour-blind safe palette based on the work of
-\url{https://www.nature.com/articles/nmeth.1618}
+\item "okabeito" (or "cbPalette"), a colour-blind safe palette based on
+the work of Masataka Okabe and Kei Ito (\url{https://jfly.uni-koeln.de/color/})
+\item "tol.bright" (or "tol"), "tol.muted" and "tol.light", colour-blind safe
+palettes based on the work of Paul Tol (\url{https://personal.sron.nl/~pault/})
+\item "tableau" and "observable", aliases for the
+"Tableau10"
+(\url{https://www.tableau.com/blog/colors-upgrade-tableau-10-56782}) and
+"Observable10" (\url{https://observablehq.com/blog/crafting-data-colors})
+colour palettes. These could be useful for consistency between openair
+plots and with figures made in Tableau or Observable Plot.
 }
 
 \strong{UK Government Palettes:}


### PR DESCRIPTION
This PR makes the following refinements to `openColours()`:

- Adds three new colourblind friendly qualitative palettes based on the work of Paul Tol.
- Adds two new palettes based on the default colour palettes of Tableau and Observable Plot (useful for consistency with plots using these frameworks)
- `openColours()` will now not error when a qualitative palette is used but `n` is left at the default of `100`. Now the full palette will be returned instead. Mainly useful for using `openColours()` outside of `{openair}`.
- `openColours()` now errors if things that aren't valid R colours or `openColours()` palettes are provided.
- `openColours()` now errors if *both* valid R colours *and* `openColours()` palettes (or multiple palettes) are provided.
- refactored to group all of the sequential and all of the qualitative palettes together, making it easier to add/refine them in future.

---

# examples

``` r
devtools::load_all()
#> ℹ Loading openair

# Won't error w/ qualitative
openColours("tol")
#> [1] "#EE6677" "#228833" "#4477AA" "#CCBB44" "#66CCEE" "#AA3377" "#BBBBBB"

# Won't error w/ valid colours
openColours(c("red", "blue", "green"), n = 10)
#>  [1] "#FF0000" "#C60038" "#8D0071" "#5500AA" "#1C00E2" "#001CE2" "#0054AA"
#>  [8] "#008D71" "#00C638" "#00FF00"

# Will error w/ invalid colours
openColours(c("red", "blue5", "greeen"))
#> Error:
#> ✖ The following are neither valid R colours nor `openColours()`
#>   palettes: blue5 and greeen

# Will error w/ multiple palettes
openColours(c("observable", "viridis"))
#> Error:
#> ✖ Please provide either 1 `openColours()` palette or a vector of valid R
#>   colours
#> ℹ See `?openColours` for a list of palettes.

# Will error w/ a combination
openColours(c("observable", "red", "blue"))
#> Error:
#> ✖ Please provide either 1 `openColours()` palette or a vector of valid R
#>   colours
#> ℹ See `?openColours` for a list of palettes.

make_timeprop <- function(pal, ...) {
  obj <-
    timeProp(
    tidyr::drop_na(mydata, o3, no2),
    pollutant = "no2",
    avg.time = "month",
    proportion = "o3",
    cols = pal,
    n.levels = 6,
    ...,
    plot = FALSE
  )
  
  return(obj$plot)
}

make_timeprop("observable")
```

![](https://i.imgur.com/6sTR6U2.png)<!-- -->

``` r

make_timeprop("tableau")
```

![](https://i.imgur.com/Kf03H4L.png)<!-- -->

``` r

make_timeprop("tol.bright")
```

![](https://i.imgur.com/qvrYyJ0.png)<!-- -->

``` r

make_timeprop("tol.muted")
```

![](https://i.imgur.com/nPEOy4D.png)<!-- -->

``` r

make_timeprop("tol.light")
```

![](https://i.imgur.com/StwKUat.png)<!-- -->

<sup>Created on 2024-10-21 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
