### PR TITLE
feat: return DAQI band along with DAQI data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: openair
 Title: Tools for the Analysis of Air Pollution Data
-Version: 2.18.2.9003
+Version: 2.18.2.9004
 Date: 2024-10-01
 Authors@R: c(
     person("David", "Carslaw", , "david.carslaw@york.ac.uk", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,17 +4,13 @@
 
 - The `source` argument of `importUKAQ()` now defaults to `NULL`. This option allows the function to assign the `source` of each `site` itself, with some caveats:
 
-	- Ambiguous codes (e.g., `"AD1"`, which corresponds to a SAQN and locally managed site) will preferentially import from the national networks (AURN, then AQE/SAQN/WAQN/NIAQN) over locally-managed networks. To override this users should manually define `source`.
+    - Ambiguous codes (e.g., `"AD1"`, which corresponds to a SAQN and locally managed site) will preferentially import from the national networks (AURN, then AQE/SAQN/WAQN/NIAQN) over locally-managed networks. To override this users should manually define `source`.
 
-	- Incorrect codes not found in `importMeta()` will error if `importUKAQ()` is left to assign the `source`.
+    - Incorrect codes not found in `importMeta()` will error if `importUKAQ()` is left to assign the `source`.
 
-	- When `data_type` is one of the aggregate types (e.g., `"annual"`) and a `site` isn't defined, a `source` must be provided.
+    - When `data_type` is one of the aggregate types (e.g., `"annual"`) and a `site` isn't defined, a `source` must be provided.
 
-	- It is likely *slightly* slower for the function to assign `source` itself than for users to specify it themselves.
-
-- The `formula.label` argument of `polarPlot()` will now control whether concentration information is printed when `statistic = "cpf"`.
-
-- add `calm.thresh` as an option to `windRose`. This change allows users to set a non-zero wind speed threshold that is considered as calm.
+    - It is likely *slightly* slower for the function to assign `source` itself than for users to specify it themselves.
 
 - Added new features for `openColours()`:
 
@@ -23,6 +19,12 @@
     - When `n` isn't defined for a qualitative palette (e.g., "Dark2"), the full qualitative palette will be returned. Previously this errored with the default of `100`.
     
     - `openColours()` will now check whether the provided `scheme` is either a known scheme name *or* a vector of valid R colours, and provide an informative error if this is not the case.
+    
+- The `formula.label` argument of `polarPlot()` will now control whether concentration information is printed when `statistic = "cpf"`.
+
+- add `calm.thresh` as an option to `windRose`. This change allows users to set a non-zero wind speed threshold that is considered as calm.
+
+- DAQI information imported using `importUKAQ(data_type = "daqi")` will be returned with the relevant DAQI band appended as an additional factor column; either "Low" (1-3), "Moderate" (4-6), "High" (7-9), or "Very High" (10). See <https://uk-air.defra.gov.uk/air-pollution/daqi> for more information.
  
 ## Bug fixes
 

--- a/R/importUKAQ.R
+++ b/R/importUKAQ.R
@@ -310,7 +310,18 @@ importUKAQ <-
           readDAQI,
           .progress = ifelse(progress, "Importing DAQI", FALSE)
         ) %>%
-        purrr::list_rbind()
+        purrr::list_rbind() %>%
+        dplyr::tibble() %>%
+        dplyr::mutate(
+          band = dplyr::case_when(
+            .data$poll_index %in% 1:3 ~ "Low",
+            .data$poll_index %in% 4:6 ~ "Moderate",
+            .data$poll_index %in% 7:9 ~ "High",
+            .data$poll_index == 10 ~ "Very High"
+          ),
+          band = factor(.data$band, c("Low", "Moderate", "High", "Very High")),
+          .after = "poll_index"
+        )
     }
 
     # Import any other stat


### PR DESCRIPTION
This PR is a small tweak to returned DAQI data. A new `band` column is appended, a factor with levels "Low", "Moderate", "High" and "Very High".

One can now therefore do:

``` r
> importUKAQ(source = "aurn", data_type = "daqi") |>
+   dplyr::count(band)
# A tibble: 4 × 2
  band           n
  <fct>      <int>
1 Low       154959
2 Moderate    1586
3 High          92
4 Very High      5
```