### PR TITLE
feat: add `breaks` and `labels` to `polarPlot()`, `polarAnnulus()` and `corPlot()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,8 @@
     
     - Added `openColors()` and `colorOpts()` which are synonymous with their British English equivalents `openColours()` and `colourOpts()`.
 
+- `polarPlot()`, `polarAnnulus()` and `corPlot()` have gained `breaks` and `labels`, which behave identically to similar arguments in functions like `trendLevel()`.
+
 - `smoothTrend()` will now use `loess` when it has insufficient data to fit a GAM.
 
 - `trajPlot()` and `trajLevel()` regain the `map.res` argument. This is passed to `rnaturalearth::ne_countries()` so can take three different resolutions.

--- a/R/corPlot.R
+++ b/R/corPlot.R
@@ -112,6 +112,8 @@ corPlot <- function(
   dendrogram = FALSE,
   triangle = c("both", "upper", "lower"),
   diagonal = TRUE,
+  breaks = NULL,
+  labels = NULL,
   cols = "default",
   r.thresh = 0.8,
   text.col = c("black", "black"),
@@ -416,6 +418,18 @@ corPlot <- function(
     x
   }
 
+  # handle breaks
+  categorical <- FALSE
+  if (!is.null(breaks)) {
+    # assign labels if no labels are given
+    labels <- get_labels_from_breaks(breaks, labels)
+    categorical <- TRUE
+    ellipse_data <- dplyr::mutate(
+      ellipse_data,
+      cor = cut(.data$cor, breaks = breaks, labels = labels)
+    )
+  }
+
   # construct plot
   thePlot <-
     ellipse_data |>
@@ -427,7 +441,8 @@ corPlot <- function(
         group = interaction(.data$x, .data$y),
         fill = .data$cor
       ),
-      color = extra.args$border %||% "transparent"
+      color = extra.args$border %||% "transparent",
+      show.legend = TRUE
     ) +
     get_facet(
       type,
@@ -454,23 +469,6 @@ corPlot <- function(
       ),
       expand = ggplot2::expansion(c(0.01, 0.01))
     ) +
-    ggplot2::scale_fill_gradientn(
-      colours = resolve_colour_opts(cols, n = 100),
-      limits = c(-1, 1),
-      oob = scales::oob_squish
-    ) +
-    ggplot2::guides(
-      fill = ggplot2::guide_colorbar(
-        theme = ggplot2::theme(
-          legend.title.position = ifelse(
-            key.position %in% c("left", "right"),
-            "top",
-            key.position
-          ),
-          legend.text.position = key.position
-        )
-      )
-    ) +
     ggplot2::labs(
       x = extra.args$xlab,
       y = extra.args$ylab,
@@ -480,6 +478,47 @@ corPlot <- function(
       tag = extra.args$tag,
       fill = key.title
     )
+
+  if (categorical) {
+    thePlot <-
+      thePlot +
+      ggplot2::scale_fill_manual(
+        values = resolve_colour_opts(cols, n = nlevels(ellipse_data$cor)),
+        drop = FALSE
+      ) +
+      ggplot2::guides(
+        fill = ggplot2::guide_legend(
+          theme = ggplot2::theme(
+            legend.title.position = ifelse(
+              key.position %in% c("left", "right"),
+              "top",
+              key.position
+            ),
+            legend.text.position = key.position
+          )
+        )
+      )
+  } else {
+    thePlot <-
+      thePlot +
+      ggplot2::scale_fill_gradientn(
+        colours = resolve_colour_opts(cols, n = 100),
+        limits = c(-1, 1),
+        oob = scales::oob_squish
+      ) +
+      ggplot2::guides(
+        fill = ggplot2::guide_colorbar(
+          theme = ggplot2::theme(
+            legend.title.position = ifelse(
+              key.position %in% c("left", "right"),
+              "top",
+              key.position
+            ),
+            legend.text.position = key.position
+          )
+        )
+      )
+  }
 
   # if dendrogram, need to use legendry to switch dendro to the opposite side of
   # the plot. else just use the base ggplot2 guides to check overlaps
@@ -501,7 +540,7 @@ corPlot <- function(
 
   # add text annotations, if requested
   if (annotate != "none") {
-    ellipse_data$cor_fmt <- round(ellipse_data$cor * 100)
+    ellipse_data$cor_fmt <- round(ellipse_data$cor_dummy * 100)
 
     annotation_column <-
       dplyr::case_when(
@@ -513,24 +552,24 @@ corPlot <- function(
 
     thePlot <- thePlot +
       ggplot2::geom_text(
-        data = dplyr::filter(ellipse_data, abs(.data$cor) < r.thresh),
+        data = dplyr::filter(ellipse_data, abs(.data$cor_dummy) < r.thresh),
         ggplot2::aes(
           x = as.numeric(.data$x),
           y = as.numeric(.data$y),
           label = .data[[annotation_column]],
-          color = factor(sign(.data$cor), c("-1", "0", "1"))
+          color = factor(sign(.data$cor_dummy), c("-1", "0", "1"))
         ),
         size = 3,
         check_overlap = TRUE,
         show.legend = FALSE
       ) +
       ggplot2::geom_text(
-        data = dplyr::filter(ellipse_data, abs(.data$cor) >= r.thresh),
+        data = dplyr::filter(ellipse_data, abs(.data$cor_dummy) >= r.thresh),
         ggplot2::aes(
           x = as.numeric(.data$x),
           y = as.numeric(.data$y),
           label = .data[[annotation_column]],
-          color = factor(sign(.data$cor), c("-1", "0", "1"))
+          color = factor(sign(.data$cor_dummy), c("-1", "0", "1"))
         ),
         size = 3,
         check_overlap = TRUE,
@@ -543,6 +582,9 @@ corPlot <- function(
           "0" = text.col[2],
           "1" = text.col[2]
         )
+      ) +
+      ggplot2::guides(
+        color = ggplot2::guide_none()
       )
   }
 

--- a/R/polarAnnulus.R
+++ b/R/polarAnnulus.R
@@ -151,6 +151,8 @@ polarAnnulus <-
     force.positive = TRUE,
     k = c(20, 10),
     normalise = FALSE,
+    breaks = NULL,
+    labels = NULL,
     strip.position = "top",
     key.title = paste(statistic, pollutant, sep = " "),
     key.position = "right",
@@ -537,6 +539,18 @@ polarAnnulus <-
     # check if key.header / key.footer are being used
     key.title <- check_key_header(key.title, extra.args)
 
+    # handle breaks
+    categorical <- FALSE
+    if (!is.null(breaks)) {
+      # assign labels if no labels are given
+      labels <- get_labels_from_breaks(breaks, labels)
+      categorical <- TRUE
+      results.grid <- dplyr::mutate(
+        results.grid,
+        pred = cut(.data$pred, breaks = breaks, labels = labels)
+      )
+    }
+
     # plotting
     thePlot <-
       ggplot2::ggplot(
@@ -566,13 +580,24 @@ polarAnnulus <-
           linewidth = 0.25
         )
       ) +
-      ggplot2::scale_fill_gradientn(
-        colours = resolve_colour_opts(cols, 100),
-        aesthetics = c("colour", "fill"),
-        limits = limits,
-        breaks = scales::breaks_pretty(6),
-        na.value = col.na
-      ) +
+      {
+        if (categorical) {
+          ggplot2::scale_fill_manual(
+            values = resolve_colour_opts(cols, nlevels(results.grid$pred)),
+            aesthetics = c("colour", "fill"),
+            na.value = col.na,
+            drop = FALSE
+          )
+        } else {
+          ggplot2::scale_fill_gradientn(
+            colours = resolve_colour_opts(cols, 100),
+            aesthetics = c("colour", "fill"),
+            limits = limits,
+            breaks = scales::breaks_pretty(6),
+            na.value = col.na
+          )
+        }
+      } +
       ggplot2::labs(
         x = extra.args$xlab,
         y = extra.args$ylab,

--- a/R/polarAnnulus.R
+++ b/R/polarAnnulus.R
@@ -599,19 +599,50 @@ polarAnnulus <-
       ) +
       {
         if (categorical) {
-          ggplot2::scale_fill_manual(
-            values = resolve_colour_opts(cols, nlevels(results.grid$pred)),
-            aesthetics = c("colour", "fill"),
-            na.value = col.na,
-            drop = FALSE
+          list(
+            ggplot2::scale_fill_manual(
+              values = resolve_colour_opts(cols, nlevels(results.grid$pred)),
+              aesthetics = c("colour", "fill"),
+              na.value = col.na,
+              drop = FALSE
+            ),
+            ggplot2::guides(
+              fill = ggplot2::guide_legend(
+                reverse = TRUE,
+                theme = ggplot2::theme(
+                  legend.title.position = ifelse(
+                    key.position %in% c("left", "right"),
+                    "top",
+                    key.position
+                  ),
+                  legend.text.position = key.position
+                )
+              ),
+              color = ggplot2::guide_none()
+            )
           )
         } else {
-          ggplot2::scale_fill_gradientn(
-            colours = resolve_colour_opts(cols, 100),
-            aesthetics = c("colour", "fill"),
-            limits = limits,
-            breaks = scales::breaks_pretty(6),
-            na.value = col.na
+          list(
+            ggplot2::scale_fill_gradientn(
+              colours = resolve_colour_opts(cols, 100),
+              aesthetics = c("colour", "fill"),
+              limits = limits,
+              breaks = scales::breaks_pretty(6),
+              na.value = col.na
+            ),
+            ggplot2::guides(
+              fill = ggplot2::guide_colorbar(
+                theme = ggplot2::theme(
+                  legend.title.position = ifelse(
+                    key.position %in% c("left", "right"),
+                    "top",
+                    key.position
+                  ),
+                  legend.text.position = key.position
+                )
+              ),
+              color = ggplot2::guide_none()
+            )
           )
         }
       } +

--- a/R/polarAnnulus.R
+++ b/R/polarAnnulus.R
@@ -272,16 +272,33 @@ polarAnnulus <-
       na.rm = TRUE
     )
 
-    if (statistic == "cpf") {
-      sub <- paste0(
-        "CPF probability at the ",
-        percentile,
-        "th percentile (=",
-        round(Pval, 1),
-        ")"
+    # handle caption
+    sub <- NULL
+    if (extra.args$annotate %||% TRUE) {
+      if (statistic == "cpf") {
+        sub <- paste0(
+          "CPF probability at the ",
+          percentile,
+          "th percentile (=",
+          round(Pval, 1),
+          ")"
+        )
+      } else {
+        sub <- NULL
+      }
+
+      sub <- paste(
+        list(
+          "hour" = "Radial axis shows hour of the day",
+          "weekday" = "Radial axis shows day of the week",
+          "season" = "Radial axis shows month of the year",
+          "trend" = NULL
+        )[[period]],
+        sub,
+        sep = "\n"
       )
-    } else {
-      sub <- NULL
+
+      sub <- quickText(sub, auto.text = auto.text)
     }
 
     prepare.grid <- function(mydata) {

--- a/R/polarPlot.R
+++ b/R/polarPlot.R
@@ -992,7 +992,7 @@ polarPlot <-
         )
       ) +
       ggplot2::labs(
-        color = legend_title,
+        fill = legend_title,
         x = extra.args$xlab,
         y = extra.args$ylab,
         title = extra.args$title,

--- a/R/polarPlot.R
+++ b/R/polarPlot.R
@@ -207,9 +207,9 @@
 #'   removing real data points. It is recommended to consider your data with
 #'   care. Also, the `polarFreq` function can be of use in such circumstances.
 #'
-#' @param mis.col When `min.bin` is > 1 it can be useful to show where data are
+#' @param col.na When `min.bin` is > 1 it can be useful to show where data are
 #'   removed on the plots. This is done by shading the missing data in
-#'   `mis.col`. To not highlight missing data when `min.bin` > 1 choose `mis.col
+#'   `col.na`. To not highlight missing data when `min.bin` > 1 choose `col.na
 #'   = "transparent"`.
 #'
 #' @param upper This sets the upper limit wind speed to be used. Often there are
@@ -368,7 +368,7 @@ polarPlot <-
     cols = "default",
     weights = c(0.25, 0.5, 0.75),
     min.bin = 1,
-    mis.col = "grey",
+    col.na = "grey",
     upper = NA,
     angle.scale = 315,
     units = x,
@@ -465,6 +465,7 @@ polarPlot <-
 
     # extra.args setup
     extra.args <- capture_dots(...)
+    col.na <- extra.args$mis.col %||% col.na
 
     # label controls
     extra.args$xlab <- quickText(extra.args$xlab, auto.text)
@@ -917,7 +918,9 @@ polarPlot <-
       dplyr::arrange(!is.na(.data$z), .data$z) |>
       ggplot2::ggplot(ggplot2::aes(x = .data$wd, y = .data$x)) +
       ggplot2::geom_point(
-        ggplot2::aes(colour = .data$z),
+        ggplot2::aes(colour = .data$z, fill = .data$z),
+        shape = 21,
+        key_glyph = "rect",
         show.legend = TRUE
       ) +
       ggplot2::ggproto(
@@ -935,12 +938,13 @@ polarPlot <-
           list(
             ggplot2::scale_color_manual(
               values = resolve_colour_opts(cols, nlevels(plot_data$z)),
-              na.value = mis.col,
+              aesthetics = c("fill", "colour"),
+              na.value = col.na,
               drop = FALSE
             ),
             ggplot2::guides(
-              color = ggplot2::guide_legend(
-                override.aes = list(size = 5),
+              fill = ggplot2::guide_legend(
+                reverse = TRUE,
                 theme = ggplot2::theme(
                   legend.title.position = ifelse(
                     key.position %in% c("left", "right"),
@@ -949,19 +953,21 @@ polarPlot <-
                   ),
                   legend.text.position = key.position
                 )
-              )
+              ),
+              color = ggplot2::guide_none()
             )
           )
         } else {
           list(
             ggplot2::scale_color_gradientn(
               colours = resolve_colour_opts(cols, 100),
+              aesthetics = c("fill", "colour"),
               oob = scales::oob_squish,
-              na.value = mis.col,
+              na.value = col.na,
               limits = limits
             ),
             ggplot2::guides(
-              color = ggplot2::guide_colorbar(
+              fill = ggplot2::guide_colorbar(
                 theme = ggplot2::theme(
                   legend.title.position = ifelse(
                     key.position %in% c("left", "right"),
@@ -970,7 +976,8 @@ polarPlot <-
                   ),
                   legend.text.position = key.position
                 )
-              )
+              ),
+              color = ggplot2::guide_none()
             )
           )
         }

--- a/R/polarPlot.R
+++ b/R/polarPlot.R
@@ -375,6 +375,8 @@ polarPlot <-
     force.positive = TRUE,
     k = 100,
     normalise = FALSE,
+    breaks = NULL,
+    labels = NULL,
     key.title = paste(statistic, pollutant, sep = " "),
     key.position = "right",
     strip.position = "top",
@@ -898,11 +900,26 @@ polarPlot <-
       limits <- NULL
     }
 
+    # handle breaks
+    categorical <- FALSE
+    if (!is.null(breaks)) {
+      # assign labels if no labels are given
+      labels <- get_labels_from_breaks(breaks, labels)
+      categorical <- TRUE
+      plot_data <- dplyr::mutate(
+        plot_data,
+        z = cut(.data$z, breaks = breaks, labels = labels)
+      )
+    }
+
     thePlot <-
       plot_data |>
       dplyr::arrange(!is.na(.data$z), .data$z) |>
       ggplot2::ggplot(ggplot2::aes(x = .data$wd, y = .data$x)) +
-      ggplot2::geom_point(ggplot2::aes(colour = .data$z)) +
+      ggplot2::geom_point(
+        ggplot2::aes(colour = .data$z),
+        show.legend = TRUE
+      ) +
       ggplot2::ggproto(
         NULL,
         ggplot2::coord_radial(r.axis.inside = angle.scale),
@@ -913,12 +930,51 @@ polarPlot <-
         limits = range(pretty(plot_data$x, 20)),
         expand = ggplot2::expansion()
       ) +
-      ggplot2::scale_color_gradientn(
-        colours = resolve_colour_opts(cols, 100),
-        oob = scales::oob_squish,
-        na.value = mis.col,
-        limits = limits
-      ) +
+      {
+        if (categorical) {
+          list(
+            ggplot2::scale_color_manual(
+              values = resolve_colour_opts(cols, nlevels(plot_data$z)),
+              na.value = mis.col,
+              drop = FALSE
+            ),
+            ggplot2::guides(
+              color = ggplot2::guide_legend(
+                override.aes = list(size = 5),
+                theme = ggplot2::theme(
+                  legend.title.position = ifelse(
+                    key.position %in% c("left", "right"),
+                    "top",
+                    key.position
+                  ),
+                  legend.text.position = key.position
+                )
+              )
+            )
+          )
+        } else {
+          list(
+            ggplot2::scale_color_gradientn(
+              colours = resolve_colour_opts(cols, 100),
+              oob = scales::oob_squish,
+              na.value = mis.col,
+              limits = limits
+            ),
+            ggplot2::guides(
+              color = ggplot2::guide_colorbar(
+                theme = ggplot2::theme(
+                  legend.title.position = ifelse(
+                    key.position %in% c("left", "right"),
+                    "top",
+                    key.position
+                  ),
+                  legend.text.position = key.position
+                )
+              )
+            )
+          )
+        }
+      } +
       theme_openair_radial(key.position, panel.ontop = TRUE) +
       set_extra_fontsize(extra.args) +
       annotate_compass_points(
@@ -960,18 +1016,6 @@ polarPlot <-
         auto.text = auto.text,
         strip.position = strip.position,
         wd.res = extra.args$wd.res %||% 8
-      ) +
-      ggplot2::guides(
-        color = ggplot2::guide_colorbar(
-          theme = ggplot2::theme(
-            legend.title.position = ifelse(
-              key.position %in% c("left", "right"),
-              "top",
-              key.position
-            ),
-            legend.text.position = key.position
-          )
-        )
       )
 
     if (plot) {

--- a/man/corPlot.Rd
+++ b/man/corPlot.Rd
@@ -15,6 +15,8 @@ corPlot(
   dendrogram = FALSE,
   triangle = c("both", "upper", "lower"),
   diagonal = TRUE,
+  breaks = NULL,
+  labels = NULL,
   cols = "default",
   r.thresh = 0.8,
   text.col = c("black", "black"),
@@ -86,6 +88,16 @@ Can be \code{"both"}, \code{"lower"} or \code{"upper"}. Defaults to \code{"both"
 \item{diagonal}{Should the 'diagonal' of the correlation plot be shown? The
 diagonal of a correlation matrix is axiomatically always \code{1} as it
 represents correlating a variable with itself. Defaults to \code{TRUE}.}
+
+\item{breaks, labels}{If a categorical colour scale is required then \code{breaks}
+should be specified. These should be provided as a numeric vector, e.g.,
+\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
+\code{breaks} to exceed the maximum data value to ensure it is within the
+maximum final range, e.g., 100--1000 in this case. Labels will
+automatically be generated, but can be customised by passing a character
+vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
+example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
+than break.}
 
 \item{cols}{Colours to use for plotting. Can be a pre-set palette (e.g.,
 \code{"turbo"}, \code{"viridis"}, \code{"tol"}, \code{"Dark2"}, etc.) or a user-defined vector

--- a/man/polarAnnulus.Rd
+++ b/man/polarAnnulus.Rd
@@ -24,6 +24,8 @@ polarAnnulus(
   force.positive = TRUE,
   k = c(20, 10),
   normalise = FALSE,
+  breaks = NULL,
+  labels = NULL,
   strip.position = "top",
   key.title = paste(statistic, pollutant, sep = " "),
   key.position = "right",
@@ -180,6 +182,16 @@ mean value. This is done \emph{after} fitting the smooth surface. This option is
 particularly useful if one is interested in the patterns of concentrations
 for several pollutants on different scales e.g. NOx and CO. Often useful if
 more than one \code{pollutant} is chosen.}
+
+\item{breaks, labels}{If a categorical colour scale is required then \code{breaks}
+should be specified. These should be provided as a numeric vector, e.g.,
+\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
+\code{breaks} to exceed the maximum data value to ensure it is within the
+maximum final range, e.g., 100--1000 in this case. Labels will
+automatically be generated, but can be customised by passing a character
+vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
+example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
+than break.}
 
 \item{strip.position}{Location where the facet 'strips' are located when
 using \code{type}. When one \code{type} is provided, can be one of \code{"left"},

--- a/man/polarCluster.Rd
+++ b/man/polarCluster.Rd
@@ -266,6 +266,15 @@ possible pollutant source is active or not).
 
 Most \code{openair} plotting functions can take two \code{type} arguments. If two are
 given, the first is used for the columns and the second for the rows.}
+    \item{\code{breaks,labels}}{If a categorical colour scale is required then \code{breaks}
+should be specified. These should be provided as a numeric vector, e.g.,
+\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
+\code{breaks} to exceed the maximum data value to ensure it is within the
+maximum final range, e.g., 100--1000 in this case. Labels will
+automatically be generated, but can be customised by passing a character
+vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
+example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
+than break.}
     \item{\code{key.position}}{Location where the legend is to be placed. Allowed
 arguments include \code{"top"}, \code{"right"}, \code{"bottom"}, \code{"left"} and \code{"none"},
 the last of which removes the legend entirely.}

--- a/man/polarCluster.Rd
+++ b/man/polarCluster.Rd
@@ -194,9 +194,9 @@ records in each bin an so on; bins with less than 2 valid records are set
 to NA. Care should be taken when using a value > 1 because of the risk of
 removing real data points. It is recommended to consider your data with
 care. Also, the \code{polarFreq} function can be of use in such circumstances.}
-    \item{\code{mis.col}}{When \code{min.bin} is > 1 it can be useful to show where data are
+    \item{\code{col.na}}{When \code{min.bin} is > 1 it can be useful to show where data are
 removed on the plots. This is done by shading the missing data in
-\code{mis.col}. To not highlight missing data when \code{min.bin} > 1 choose \code{mis.col = "transparent"}.}
+\code{col.na}. To not highlight missing data when \code{min.bin} > 1 choose \code{col.na = "transparent"}.}
     \item{\code{upper}}{This sets the upper limit wind speed to be used. Often there are
 only a relatively few data points at very high wind speeds and plotting all
 of them can reduce the useful information in the plot.}

--- a/man/polarDiff.Rd
+++ b/man/polarDiff.Rd
@@ -187,9 +187,9 @@ records in each bin an so on; bins with less than 2 valid records are set
 to NA. Care should be taken when using a value > 1 because of the risk of
 removing real data points. It is recommended to consider your data with
 care. Also, the \code{polarFreq} function can be of use in such circumstances.}
-    \item{\code{mis.col}}{When \code{min.bin} is > 1 it can be useful to show where data are
+    \item{\code{col.na}}{When \code{min.bin} is > 1 it can be useful to show where data are
 removed on the plots. This is done by shading the missing data in
-\code{mis.col}. To not highlight missing data when \code{min.bin} > 1 choose \code{mis.col = "transparent"}.}
+\code{col.na}. To not highlight missing data when \code{min.bin} > 1 choose \code{col.na = "transparent"}.}
     \item{\code{upper}}{This sets the upper limit wind speed to be used. Often there are
 only a relatively few data points at very high wind speeds and plotting all
 of them can reduce the useful information in the plot.}

--- a/man/polarDiff.Rd
+++ b/man/polarDiff.Rd
@@ -245,6 +245,15 @@ of R colours (e.g., \code{c("yellow", "green", "blue", "black")} - see
 \code{\link[=colours]{colours()}} for a full list) or hex-codes (e.g., \code{c("#30123B", "#9CF649", "#7A0403")}). Alternatively, can be a list of arguments to control the
 colour palette more closely (e.g., \code{palette}, \code{direction}, \code{alpha}, etc.).
 See \code{\link[=openColours]{openColours()}} and \code{\link[=colourOpts]{colourOpts()}} for more details.}
+    \item{\code{breaks,labels}}{If a categorical colour scale is required then \code{breaks}
+should be specified. These should be provided as a numeric vector, e.g.,
+\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
+\code{breaks} to exceed the maximum data value to ensure it is within the
+maximum final range, e.g., 100--1000 in this case. Labels will
+automatically be generated, but can be customised by passing a character
+vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
+example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
+than break.}
     \item{\code{angle.scale}}{In radial plots (e.g., \code{\link[=polarPlot]{polarPlot()}}), the radial scale is
 drawn directly on the plot itself. While suitable defaults have been
 chosen, sometimes the placement of the scale may interfere with an

--- a/man/polarPlot.Rd
+++ b/man/polarPlot.Rd
@@ -18,7 +18,7 @@ polarPlot(
   cols = "default",
   weights = c(0.25, 0.5, 0.75),
   min.bin = 1,
-  mis.col = "grey",
+  col.na = "grey",
   upper = NA,
   angle.scale = 315,
   units = x,
@@ -217,9 +217,9 @@ to NA. Care should be taken when using a value > 1 because of the risk of
 removing real data points. It is recommended to consider your data with
 care. Also, the \code{polarFreq} function can be of use in such circumstances.}
 
-\item{mis.col}{When \code{min.bin} is > 1 it can be useful to show where data are
+\item{col.na}{When \code{min.bin} is > 1 it can be useful to show where data are
 removed on the plots. This is done by shading the missing data in
-\code{mis.col}. To not highlight missing data when \code{min.bin} > 1 choose \code{mis.col = "transparent"}.}
+\code{col.na}. To not highlight missing data when \code{min.bin} > 1 choose \code{col.na = "transparent"}.}
 
 \item{upper}{This sets the upper limit wind speed to be used. Often there are
 only a relatively few data points at very high wind speeds and plotting all

--- a/man/polarPlot.Rd
+++ b/man/polarPlot.Rd
@@ -25,6 +25,8 @@ polarPlot(
   force.positive = TRUE,
   k = 100,
   normalise = FALSE,
+  breaks = NULL,
+  labels = NULL,
   key.title = paste(statistic, pollutant, sep = " "),
   key.position = "right",
   strip.position = "top",
@@ -261,6 +263,16 @@ mean value. This is done \emph{after} fitting the smooth surface. This option is
 particularly useful if one is interested in the patterns of concentrations
 for several pollutants on different scales e.g. NOx and CO. Often useful if
 more than one \code{pollutant} is chosen.}
+
+\item{breaks, labels}{If a categorical colour scale is required then \code{breaks}
+should be specified. These should be provided as a numeric vector, e.g.,
+\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
+\code{breaks} to exceed the maximum data value to ensure it is within the
+maximum final range, e.g., 100--1000 in this case. Labels will
+automatically be generated, but can be customised by passing a character
+vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
+example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
+than break.}
 
 \item{key.title}{Used to set the title of the legend. The legend title is
 passed to \code{\link[=quickText]{quickText()}} if \code{auto.text = TRUE}.}


### PR DESCRIPTION
This PR adds `breaks` and `labels` to three more functions which return continuous axes.

This doesn't touch `scatterPlot()` yet, which is a bit more complicated, and `trajLevel()`, which is opinionated in whether it breaks the colour bar or not.

```r
polarPlot(mydata, breaks = seq(0, 300, 50))
```

<img width="743" height="482" alt="image" src="https://github.com/user-attachments/assets/01fcec6c-67f9-4d50-adf1-36f5a90ae8ab" />

```r
polarAnnulus(mydata, breaks = seq(0, 350, 50))
```

<img width="743" height="482" alt="image" src="https://github.com/user-attachments/assets/a03bb00c-b8bc-4c94-a64f-fe8af26f1611" />
