### PR TITLE
feat: add `ws` and `wd` to other polar plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -60,6 +60,8 @@
 
 - `TheilSen()` and `smoothTrend()` now use a more straightfoward way to imput missing data when `deseason = TRUE` and missing monthly data are present based on monthly linear regression by month. The user is alerted to the imputation and the monthly plot shows the imputed data as a filled grey circle.
 
+- `ws` and/or `wd` have been added to `percentileRose()`, `polarAnnulus()`, `polarDiff()` and `polarFreq()` in line with `polarPlot()`.
+
 - `polarFreq()` gains `angle.scale`, in line with all other polar coordinate plots.
 
 - New Kolmogorov-Zurbenko (KZ) Filter functions `kzFilter` and `kzaFilter`. These functions significantly enhance the capability of `{openair}` by allowing different time components to be separated and analysed separately. The `kzFilter` is considered a good default for a wide range of problems whereas the `kzaFilter` is the adaptive version that is well-suited to capturing abrumpt changes e.g. through an intervention. The range of uses of the filters will be covered in the `{openair}` book.

--- a/R/percentileRose.R
+++ b/R/percentileRose.R
@@ -29,8 +29,8 @@
 #' @inheritParams shared_openair_params
 #' @inheritParams polarPlot
 #'
-#' @param mydata A data frame minimally containing `wd` and a numeric field to
-#'   plot --- `pollutant`.
+#' @param mydata A data frame minimally containing a decimal wind direction and
+#'   a numeric field to plot.
 #'
 #' @param pollutant Mandatory. A pollutant name corresponding to a variable in a
 #'   data frame should be supplied e.g. `pollutant = "nox"`. More than one
@@ -107,6 +107,7 @@
 percentileRose <- function(
   mydata,
   pollutant = "nox",
+  ws = "ws",
   wd = "wd",
   type = "default",
   percentile = c(25, 50, 75, 90, 95),
@@ -156,8 +157,8 @@ percentileRose <- function(
   }
 
   # check to see if ws is in the data and is calm (need to remove as no wd)
-  if ("ws" %in% names(mydata)) {
-    id <- which(mydata$ws == 0 & mydata[[wd]] == 0)
+  if (ws %in% names(mydata)) {
+    id <- which(mydata[[ws]] == 0 & mydata[[wd]] == 0)
     if (length(id) > 0) {
       mydata <- mydata[-id, ]
     }
@@ -169,7 +170,7 @@ percentileRose <- function(
   mydata[[wd]] <- angle * ceiling(mydata[[wd]] / angle - 0.5)
 
   # when it generates angle at 0 and 360, make all 360
-  if (0 %in% mydata$wd) {
+  if (0 %in% mydata[[wd]]) {
     id <- which(mydata[[wd]] == 0)
     mydata[[wd]][id] <- 360
   }
@@ -302,7 +303,8 @@ percentileRose <- function(
 
     if (method == "default") {
       ## calculate percentiles
-      percentiles <- dplyr::group_by(mydata, wd) |>
+      percentiles <- mydata |>
+        dplyr::group_by(.data[[wd]]) |>
         dplyr::reframe(
           {{ pollutant }} := stats::quantile(
             .data[[pollutant]],
@@ -310,12 +312,13 @@ percentileRose <- function(
             na.rm = TRUE
           )
         ) |>
-        dplyr::group_by(wd) |>
+        dplyr::group_by(.data[[wd]]) |>
         dplyr::mutate(percentile = percentile)
     }
 
     if (tolower(method) == "cpf") {
-      percentiles1 <- dplyr::group_by(mydata, wd) |>
+      percentiles1 <- mydata |>
+        dplyr::group_by(.data[[wd]]) |>
         dplyr::summarise(dplyr::across(
           dplyr::where(is.numeric),
           ~ length(which(.x < overall.lower)) / length(.x)
@@ -323,7 +326,8 @@ percentileRose <- function(
 
       percentiles1$percentile <- min(percentile)
 
-      percentiles2 <- dplyr::group_by(mydata, wd) |>
+      percentiles2 <- mydata |>
+        dplyr::group_by(.data[[wd]]) |>
         dplyr::summarise(dplyr::across(
           dplyr::where(is.numeric),
           ~ length(which(.x > upper)) / length(.x)
@@ -358,7 +362,8 @@ percentileRose <- function(
 
     ## calculate mean; assume a percentile of 999 to flag it later
 
-    percentiles <- dplyr::group_by(mydata, wd) |>
+    percentiles <- mydata |>
+      dplyr::group_by(.data[[wd]]) |>
       dplyr::summarise(dplyr::across(
         dplyr::where(is.numeric),
         ~ mean(.x, na.rm = TRUE)
@@ -617,7 +622,16 @@ percentileRose <- function(
     plot(thePlot)
   }
 
-  output <- list(plot = thePlot, data = results.grid, call = match.call())
+  # standardise output data
+  out_data <- dplyr::ungroup(results.grid)
+  names(out_data)[names(out_data) == wd] <- "wd"
+
+  # output
+  output <- list(
+    plot = thePlot,
+    data = out_data,
+    call = match.call()
+  )
   class(output) <- "openair"
 
   invisible(output)

--- a/R/polarAnnulus.R
+++ b/R/polarAnnulus.R
@@ -5,13 +5,13 @@
 #' concentrations of pollutants vary by wind direction and a time period e.g. by
 #' month, day of week.
 #'
-#' The `polarAnnulus` function shares many of the properties of the
-#' `polarPlot`. However, `polarAnnulus` is focussed on displaying
-#' information on how concentrations of a pollutant (values of another variable)
-#' vary with wind direction and time. Plotting as an annulus helps to reduce
-#' compression of information towards the centre of the plot. The circular plot
-#' is easy to interpret because wind direction is most easily understood in
-#' polar rather than Cartesian coordinates.
+#' The `polarAnnulus` function shares many of the properties of the `polarPlot`.
+#' However, `polarAnnulus` is focussed on displaying information on how
+#' concentrations of a pollutant (values of another variable) vary with wind
+#' direction and time. Plotting as an annulus helps to reduce compression of
+#' information towards the centre of the plot. The circular plot is easy to
+#' interpret because wind direction is most easily understood in polar rather
+#' than Cartesian coordinates.
 #'
 #' The inner part of the annulus represents the earliest time and the outer part
 #' of the annulus the latest time. The time dimension can be shown in many ways
@@ -21,8 +21,8 @@
 #' be very useful for understanding how different source influences affect a
 #' location.
 #'
-#' For `type = "trend"` the amount of smoothing does not vary linearly with
-#' the length of the time series i.e. a certain amount of smoothing per unit
+#' For `type = "trend"` the amount of smoothing does not vary linearly with the
+#' length of the time series i.e. a certain amount of smoothing per unit
 #' interval in time. This is a deliberate choice because should one be
 #' interested in a subset (in time) of data, more detail will be provided for
 #' the subset compared with the full data set. This allows users to investigate
@@ -32,8 +32,8 @@
 #' @inheritParams shared_openair_params
 #' @inheritParams polarPlot
 #'
-#' @param mydata A data frame minimally containing `date`, `wd` and a
-#'   pollutant.
+#' @param mydata A data frame minimally containing `date`, a wind direction and
+#'   a pollutant.
 #'
 #' @param pollutant Mandatory. A pollutant name corresponding to a variable in a
 #'   data frame should be supplied e.g. `pollutant = "nox"`. There can also be
@@ -134,6 +134,7 @@ polarAnnulus <-
   function(
     mydata,
     pollutant = "nox",
+    wd = "wd",
     resolution = "fine",
     local.tz = NULL,
     period = "hour",
@@ -191,7 +192,7 @@ polarAnnulus <-
     }
 
     # extract variables of interest
-    vars <- c("wd", "date", pollutant)
+    vars <- c(wd, "date", pollutant)
 
     if (period == "trend" && "season" %in% type) {
       cli::cli_abort(
@@ -236,10 +237,10 @@ polarAnnulus <-
     }
 
     # add extra wds - reduces discontinuity at 0/360
-    zero.wd <- dplyr::filter(mydata, .data$wd == 360)
+    zero.wd <- dplyr::filter(mydata, .data[[wd]] == 360)
 
     if (nrow(zero.wd) > 0) {
-      zero.wd$wd <- 0
+      zero.wd[[wd]] <- 0
       mydata <- rbind(mydata, zero.wd)
     }
 
@@ -369,11 +370,15 @@ polarAnnulus <-
 
       time.seq <- seq(0, 10, length = 24)
 
-      wd <- seq(from = 0, to = 360, 10) # wind directions from 10 to 360
-      ws.wd <- expand.grid(time.seq = time.seq, wd = wd)
+      wd_seq <- seq(from = 0, to = 360, 10) # wind directions from 10 to 360
+      ws.wd <- expand.grid(time.seq = time.seq, wd = wd_seq)
 
       # identify which ws and wd bins the data belong
-      wd.cut <- cut(mydata$wd, seq(0, 360, length = 38), include.lowest = TRUE)
+      wd.cut <- cut(
+        mydata[[wd]],
+        seq(0, 360, length = 38),
+        include.lowest = TRUE
+      )
 
       # divide-up the data for the annulus
       time.cut <- cut(
@@ -441,7 +446,7 @@ polarAnnulus <-
 
       # data to predict over
       time.seq <- ws.wd$time.seq
-      wd <- ws.wd$wd
+      wd_seq <- ws.wd$wd
 
       input.data <- expand.grid(
         time.seq = seq(0, 10, length = len.int),
@@ -456,7 +461,7 @@ polarAnnulus <-
         n <- 1
       }
 
-      input <- data.frame(binned, time.seq, wd)
+      input <- data.frame(binned, time.seq, wd = wd_seq)
 
       # note use of cyclic smooth for the wind direction component
       Mgam <- mgcv::gam(

--- a/R/polarDiff.R
+++ b/R/polarDiff.R
@@ -42,8 +42,9 @@ polarDiff <- function(
   before,
   after,
   pollutant = "nox",
-  type = "default",
   x = "ws",
+  wd = "wd",
+  type = "default",
   limits = NULL,
   auto.text = TRUE,
   plot = TRUE,
@@ -54,9 +55,9 @@ polarDiff <- function(
 
   # variables needed, check for York regression where x and y error needed
   vars <- if (all(c("x_error", "y_error") %in% names(extra.args))) {
-    c(x, "wd", pollutant, extra.args$x_error, extra.args$y_error)
+    c(x, wd, pollutant, extra.args$x_error, extra.args$y_error)
   } else {
-    c(x, "wd", pollutant)
+    c(x, wd, pollutant)
   }
 
   # collapse multi-pollutant name once, used throughout
@@ -89,6 +90,7 @@ polarDiff <- function(
           theData,
           pollutant = pollutant,
           x = x,
+          wd = wd,
           type = "period",
           plot = FALSE,
           ...
@@ -163,6 +165,7 @@ polarDiff <- function(
         mydata = polar_data,
         pollutant = pollutant,
         x = x,
+        wd = "wd",
         limits = resolved_limits,
         force.positive = FALSE,
         plot = FALSE,

--- a/R/polarFreq.R
+++ b/R/polarFreq.R
@@ -30,7 +30,8 @@
 #' @inheritParams shared_openair_params
 #' @inheritParams polarPlot
 #'
-#' @param mydata A data frame minimally containing `ws`, `wd` and `date`.
+#' @param mydata A data frame minimally containing a wind speed, a decimal wind
+#'   direction, and `date`.
 #'
 #' @param pollutant Mandatory. A pollutant name corresponding to a variable in a
 #'   data frame should be supplied e.g. `pollutant = "nox"`
@@ -130,6 +131,8 @@
 polarFreq <- function(
   mydata,
   pollutant = NULL,
+  ws = "ws",
+  wd = "wd",
   statistic = "frequency",
   ws.int = 1,
   wd.nint = 36,
@@ -157,7 +160,7 @@ polarFreq <- function(
   key.position <- check_key_position(key.position, key)
 
   # extract necessary data
-  vars <- c("wd", "ws")
+  vars <- c(wd, ws)
   if (any(type %in% dateTypes)) {
     vars <- c(vars, "date")
   }
@@ -184,8 +187,8 @@ polarFreq <- function(
   mydata <- checkPrep(mydata, vars, type, remove.calm = FALSE)
 
   # to make first interval easier to work with, set ws = 0 + e
-  ids <- which(mydata$ws == 0)
-  mydata$ws[ids] <- mydata$ws[ids] + 0.0001
+  ids <- which(mydata[[ws]] == 0)
+  mydata[[ws]][ids] <- mydata[[ws]][ids] + 0.0001
 
   # remove all NAs
   mydata <- stats::na.omit(mydata)
@@ -219,16 +222,16 @@ polarFreq <- function(
   key.title <- gsub("weighted.mean", "contribution (%)", key.title)
 
   # make sure wd data are rounded to nearest 10
-  mydata$wd <- wd.int * ceiling(mydata$wd / wd.int - 0.5)
+  mydata$wd <- wd.int * ceiling(mydata[[wd]] / wd.int - 0.5)
 
   prepare.grid <- function(mydata) {
-    mydata$wd[mydata$wd == 360] <- 0
-    wd <- factor(mydata$wd)
-    ws <- factor(ws.int * ceiling(mydata$ws / ws.int))
+    mydata[[wd]][mydata$wd == 360] <- 0
+    wd_vec <- factor(mydata[[wd]])
+    ws_vec <- factor(ws.int * ceiling(mydata[[ws]] / ws.int))
 
     if (statistic == "frequency") {
       # case with only ws and wd
-      weights <- tapply(mydata$ws, list(wd, ws), function(x) {
+      weights <- tapply(mydata[[ws]], list(wd_vec, ws_vec), function(x) {
         length(stats::na.omit(x))
       })
     }
@@ -236,7 +239,7 @@ polarFreq <- function(
     if (statistic == "mean") {
       weights <- tapply(
         mydata[[pollutant]],
-        list(wd, ws),
+        list(wd_vec, ws_vec),
         function(x) mean(x, na.rm = TRUE)
       )
     }
@@ -244,7 +247,7 @@ polarFreq <- function(
     if (statistic == "median") {
       weights <- tapply(
         mydata[[pollutant]],
-        list(wd, ws),
+        list(wd_vec, ws_vec),
         function(x) stats::median(x, na.rm = TRUE)
       )
     }
@@ -252,7 +255,7 @@ polarFreq <- function(
     if (statistic == "max") {
       weights <- tapply(
         mydata[[pollutant]],
-        list(wd, ws),
+        list(wd_vec, ws_vec),
         function(x) max(x, na.rm = TRUE)
       )
     }
@@ -260,7 +263,7 @@ polarFreq <- function(
     if (statistic == "stdev") {
       weights <- tapply(
         mydata[[pollutant]],
-        list(wd, ws),
+        list(wd_vec, ws_vec),
         function(x) stats::sd(x, na.rm = TRUE)
       )
     }
@@ -268,7 +271,7 @@ polarFreq <- function(
     if (statistic == "weighted.mean") {
       weights <- tapply(
         mydata[[pollutant]],
-        list(wd, ws),
+        list(wd_vec, ws_vec),
         function(x) (mean(x) * length(x) / nrow(mydata))
       )
 
@@ -279,7 +282,7 @@ polarFreq <- function(
     weights <- as.vector(t(weights))
 
     # frequency - remove points with freq < min.bin
-    bin.len <- tapply(mydata$ws, list(wd, ws), function(x) {
+    bin.len <- tapply(mydata[[ws]], list(wd_vec, ws_vec), function(x) {
       length(stats::na.omit(x))
     })
     binned.len <- as.vector(t(bin.len))
@@ -287,8 +290,8 @@ polarFreq <- function(
     weights[ids] <- NA
 
     ws.wd <- expand.grid(
-      ws = as.numeric(levels(ws)),
-      wd = as.numeric(levels(wd))
+      ws = as.numeric(levels(ws_vec)),
+      wd = as.numeric(levels(wd_vec))
     )
 
     weights <- cbind(ws.wd, weights)

--- a/R/polarPlot.R
+++ b/R/polarPlot.R
@@ -61,10 +61,10 @@
 #'
 #' @inheritParams shared_openair_params
 #'
-#' @param mydata A data frame minimally containing `wd`, another variable to
-#'   plot in polar coordinates (the default is a column \dQuote{ws} --- wind
-#'   speed) and a pollutant. Should also contain `date` if plots by time period
-#'   are required.
+#' @param mydata A data frame minimally containing a decimal wind direction,
+#'   another variable to plot in polar coordinates (the default is a column
+#'   `"ws"` --- wind speed) and a pollutant. Should also contain `date` if plots
+#'   by time period are required.
 #'
 #' @param pollutant Mandatory. A pollutant name corresponding to a variable in a
 #'   data frame should be supplied e.g. `pollutant = "nox"`. There can also be
@@ -81,8 +81,6 @@
 #'
 #' @param x Name of variable to plot against wind direction in polar
 #'   coordinates, the default is wind speed, \dQuote{ws}.
-#'
-#' @param wd Name of wind direction field.
 #'
 #' @param statistic The statistic that should be applied to each wind
 #'   speed/direction bin. Because of the smoothing involved, the colour scale
@@ -208,9 +206,9 @@
 #'   care. Also, the `polarFreq` function can be of use in such circumstances.
 #'
 #' @param col.na When `min.bin` is > 1 it can be useful to show where data are
-#'   removed on the plots. This is done by shading the missing data in
-#'   `col.na`. To not highlight missing data when `min.bin` > 1 choose `col.na
-#'   = "transparent"`.
+#'   removed on the plots. This is done by shading the missing data in `col.na`.
+#'   To not highlight missing data when `min.bin` > 1 choose `col.na =
+#'   "transparent"`.
 #'
 #' @param upper This sets the upper limit wind speed to be used. Often there are
 #'   only a relatively few data points at very high wind speeds and plotting all
@@ -1035,7 +1033,11 @@ polarPlot <-
 
     # return attribute of scale used - useful for data with negative scales such as air_temp
     attr(newdata, "radial_scale") <- range(radial_scale)
-    output <- list(plot = thePlot, data = newdata, call = match.call())
+    output <- list(
+      plot = thePlot,
+      data = dplyr::tibble(newdata),
+      call = match.call()
+    )
     class(output) <- "openair"
 
     # Final return

--- a/R/shared-docs.R
+++ b/R/shared-docs.R
@@ -3,6 +3,13 @@
 #' @description This is a central place for describing common shared parameters.
 #'   This ensures consistency across `openair`
 #'
+#' @param ws The name of the column in `mydata` representing the wind speed.
+#'   Defaults to `"ws"`.
+#'
+#' @param wd The name of the column in `mydata` representing the decimal wind
+#'   direction, 0 to 360 where 0/360 are North and 180 is South. Defaults to
+#'   `"wd"`.
+#'
 #' @param type Character string(s) defining how data should be split/conditioned
 #'   before plotting. `"default"` produces a single panel using the entire
 #'   dataset. Any other options will split the plot into different panels - a

--- a/R/windRose.R
+++ b/R/windRose.R
@@ -26,10 +26,6 @@
 #'
 #' @param mydata A data frame containing fields `ws` and `wd`
 #'
-#' @param ws Name of the column representing wind speed.
-#'
-#' @param wd Name of the column representing wind direction.
-#'
 #' @param ws2,wd2 The user can supply a second set of wind speed and wind
 #'   direction values with which the first can be compared. See
 #'   [pollutionRose()] for more details.

--- a/man/percentileRose.Rd
+++ b/man/percentileRose.Rd
@@ -7,6 +7,7 @@
 percentileRose(
   mydata,
   pollutant = "nox",
+  ws = "ws",
   wd = "wd",
   type = "default",
   percentile = c(25, 50, 75, 90, 95),
@@ -32,15 +33,20 @@ percentileRose(
 )
 }
 \arguments{
-\item{mydata}{A data frame minimally containing \code{wd} and a numeric field to
-plot --- \code{pollutant}.}
+\item{mydata}{A data frame minimally containing a decimal wind direction and
+a numeric field to plot.}
 
 \item{pollutant}{Mandatory. A pollutant name corresponding to a variable in a
 data frame should be supplied e.g. \code{pollutant = "nox"}. More than one
 pollutant can be supplied e.g. \code{pollutant = c("no2", "o3")} provided there
 is only one \code{type}.}
 
-\item{wd}{Name of wind direction field.}
+\item{ws}{The name of the column in \code{mydata} representing the wind speed.
+Defaults to \code{"ws"}.}
+
+\item{wd}{The name of the column in \code{mydata} representing the decimal wind
+direction, 0 to 360 where 0/360 are North and 180 is South. Defaults to
+\code{"wd"}.}
 
 \item{type}{Character string(s) defining how data should be split/conditioned
 before plotting. \code{"default"} produces a single panel using the entire

--- a/man/polarAnnulus.Rd
+++ b/man/polarAnnulus.Rd
@@ -7,6 +7,7 @@
 polarAnnulus(
   mydata,
   pollutant = "nox",
+  wd = "wd",
   resolution = "fine",
   local.tz = NULL,
   period = "hour",
@@ -36,8 +37,8 @@ polarAnnulus(
 )
 }
 \arguments{
-\item{mydata}{A data frame minimally containing \code{date}, \code{wd} and a
-pollutant.}
+\item{mydata}{A data frame minimally containing \code{date}, a wind direction and
+a pollutant.}
 
 \item{pollutant}{Mandatory. A pollutant name corresponding to a variable in a
 data frame should be supplied e.g. \code{pollutant = "nox"}. There can also be
@@ -48,6 +49,10 @@ user stacking the data and it is possible to work with columns of data
 directly. A typical use would be \code{pollutant = c("obs", "mod")} to compare
 two columns \dQuote{obs} (the observations) and \dQuote{mod} (modelled
 values).}
+
+\item{wd}{The name of the column in \code{mydata} representing the decimal wind
+direction, 0 to 360 where 0/360 are North and 180 is South. Defaults to
+\code{"wd"}.}
 
 \item{resolution}{Two plot resolutions can be set: \dQuote{normal} and
 \dQuote{fine} (the default).}
@@ -255,13 +260,13 @@ concentrations of pollutants vary by wind direction and a time period e.g. by
 month, day of week.
 }
 \details{
-The \code{polarAnnulus} function shares many of the properties of the
-\code{polarPlot}. However, \code{polarAnnulus} is focussed on displaying
-information on how concentrations of a pollutant (values of another variable)
-vary with wind direction and time. Plotting as an annulus helps to reduce
-compression of information towards the centre of the plot. The circular plot
-is easy to interpret because wind direction is most easily understood in
-polar rather than Cartesian coordinates.
+The \code{polarAnnulus} function shares many of the properties of the \code{polarPlot}.
+However, \code{polarAnnulus} is focussed on displaying information on how
+concentrations of a pollutant (values of another variable) vary with wind
+direction and time. Plotting as an annulus helps to reduce compression of
+information towards the centre of the plot. The circular plot is easy to
+interpret because wind direction is most easily understood in polar rather
+than Cartesian coordinates.
 
 The inner part of the annulus represents the earliest time and the outer part
 of the annulus the latest time. The time dimension can be shown in many ways
@@ -271,8 +276,8 @@ how concentrations vary by hour of the day and wind direction. Such plots can
 be very useful for understanding how different source influences affect a
 location.
 
-For \code{type = "trend"} the amount of smoothing does not vary linearly with
-the length of the time series i.e. a certain amount of smoothing per unit
+For \code{type = "trend"} the amount of smoothing does not vary linearly with the
+length of the time series i.e. a certain amount of smoothing per unit
 interval in time. This is a deliberate choice because should one be
 interested in a subset (in time) of data, more detail will be provided for
 the subset compared with the full data set. This allows users to investigate

--- a/man/polarCluster.Rd
+++ b/man/polarCluster.Rd
@@ -21,10 +21,10 @@ polarCluster(
 )
 }
 \arguments{
-\item{mydata}{A data frame minimally containing \code{wd}, another variable to
-plot in polar coordinates (the default is a column \dQuote{ws} --- wind
-speed) and a pollutant. Should also contain \code{date} if plots by time period
-are required.}
+\item{mydata}{A data frame minimally containing a decimal wind direction,
+another variable to plot in polar coordinates (the default is a column
+\code{"ws"} --- wind speed) and a pollutant. Should also contain \code{date} if plots
+by time period are required.}
 
 \item{pollutant}{Mandatory. A pollutant name corresponding to a variable in a
 data frame should be supplied e.g. \code{pollutant = "nox"}. Only one pollutant
@@ -33,7 +33,9 @@ can be chosen.}
 \item{x}{Name of variable to plot against wind direction in polar
 coordinates, the default is wind speed, \dQuote{ws}.}
 
-\item{wd}{Name of wind direction field.}
+\item{wd}{The name of the column in \code{mydata} representing the decimal wind
+direction, 0 to 360 where 0/360 are North and 180 is South. Defaults to
+\code{"wd"}.}
 
 \item{n.clusters}{Number of clusters to use. If \code{n.clusters} is more than
 length 1, then a faceted plot will be output showing the clusters
@@ -195,8 +197,8 @@ to NA. Care should be taken when using a value > 1 because of the risk of
 removing real data points. It is recommended to consider your data with
 care. Also, the \code{polarFreq} function can be of use in such circumstances.}
     \item{\code{col.na}}{When \code{min.bin} is > 1 it can be useful to show where data are
-removed on the plots. This is done by shading the missing data in
-\code{col.na}. To not highlight missing data when \code{min.bin} > 1 choose \code{col.na = "transparent"}.}
+removed on the plots. This is done by shading the missing data in \code{col.na}.
+To not highlight missing data when \code{min.bin} > 1 choose \code{col.na = "transparent"}.}
     \item{\code{upper}}{This sets the upper limit wind speed to be used. Often there are
 only a relatively few data points at very high wind speeds and plotting all
 of them can reduce the useful information in the plot.}

--- a/man/polarDiff.Rd
+++ b/man/polarDiff.Rd
@@ -8,8 +8,9 @@ polarDiff(
   before,
   after,
   pollutant = "nox",
-  type = "default",
   x = "ws",
+  wd = "wd",
+  type = "default",
   limits = NULL,
   auto.text = TRUE,
   plot = TRUE,
@@ -33,6 +34,13 @@ regression techniques are to be plotted, \code{pollutant} takes two elements
 too. For example, \code{pollutant = c("bc", "pm25")} where \code{"bc"} is a function
 of \code{"pm25"}.}
 
+\item{x}{Name of variable to plot against wind direction in polar
+coordinates, the default is wind speed, \dQuote{ws}.}
+
+\item{wd}{The name of the column in \code{mydata} representing the decimal wind
+direction, 0 to 360 where 0/360 are North and 180 is South. Defaults to
+\code{"wd"}.}
+
 \item{type}{Character string(s) defining how data should be split/conditioned
 before plotting. \code{"default"} produces a single panel using the entire
 dataset. Any other options will split the plot into different panels - a
@@ -55,9 +63,6 @@ possible pollutant source is active or not).
 Most \code{openair} plotting functions can take two \code{type} arguments. If two are
 given, the first is used for the columns and the second for the rows.}
 
-\item{x}{Name of variable to plot against wind direction in polar
-coordinates, the default is wind speed, \dQuote{ws}.}
-
 \item{limits}{The function does its best to choose sensible limits
 automatically. However, there are circumstances when the user will wish to
 set different ones. An example would be a series of plots showing each year
@@ -77,7 +82,6 @@ to a file).}
 \item{...}{
   Arguments passed on to \code{\link[=polarPlot]{polarPlot}}
   \describe{
-    \item{\code{wd}}{Name of wind direction field.}
     \item{\code{statistic}}{The statistic that should be applied to each wind
 speed/direction bin. Because of the smoothing involved, the colour scale
 for some of these statistics is only to provide an indication of overall
@@ -188,8 +192,8 @@ to NA. Care should be taken when using a value > 1 because of the risk of
 removing real data points. It is recommended to consider your data with
 care. Also, the \code{polarFreq} function can be of use in such circumstances.}
     \item{\code{col.na}}{When \code{min.bin} is > 1 it can be useful to show where data are
-removed on the plots. This is done by shading the missing data in
-\code{col.na}. To not highlight missing data when \code{min.bin} > 1 choose \code{col.na = "transparent"}.}
+removed on the plots. This is done by shading the missing data in \code{col.na}.
+To not highlight missing data when \code{min.bin} > 1 choose \code{col.na = "transparent"}.}
     \item{\code{upper}}{This sets the upper limit wind speed to be used. Often there are
 only a relatively few data points at very high wind speeds and plotting all
 of them can reduce the useful information in the plot.}

--- a/man/polarFreq.Rd
+++ b/man/polarFreq.Rd
@@ -7,6 +7,8 @@
 polarFreq(
   mydata,
   pollutant = NULL,
+  ws = "ws",
+  wd = "wd",
   statistic = "frequency",
   ws.int = 1,
   wd.nint = 36,
@@ -32,10 +34,18 @@ polarFreq(
 )
 }
 \arguments{
-\item{mydata}{A data frame minimally containing \code{ws}, \code{wd} and \code{date}.}
+\item{mydata}{A data frame minimally containing a wind speed, a decimal wind
+direction, and \code{date}.}
 
 \item{pollutant}{Mandatory. A pollutant name corresponding to a variable in a
 data frame should be supplied e.g. \code{pollutant = "nox"}}
+
+\item{ws}{The name of the column in \code{mydata} representing the wind speed.
+Defaults to \code{"ws"}.}
+
+\item{wd}{The name of the column in \code{mydata} representing the decimal wind
+direction, 0 to 360 where 0/360 are North and 180 is South. Defaults to
+\code{"wd"}.}
 
 \item{statistic}{The statistic that should be applied to each wind
 speed/direction bin. Can be one of:

--- a/man/polarPlot.Rd
+++ b/man/polarPlot.Rd
@@ -44,10 +44,10 @@ polarPlot(
 )
 }
 \arguments{
-\item{mydata}{A data frame minimally containing \code{wd}, another variable to
-plot in polar coordinates (the default is a column \dQuote{ws} --- wind
-speed) and a pollutant. Should also contain \code{date} if plots by time period
-are required.}
+\item{mydata}{A data frame minimally containing a decimal wind direction,
+another variable to plot in polar coordinates (the default is a column
+\code{"ws"} --- wind speed) and a pollutant. Should also contain \code{date} if plots
+by time period are required.}
 
 \item{pollutant}{Mandatory. A pollutant name corresponding to a variable in a
 data frame should be supplied e.g. \code{pollutant = "nox"}. There can also be
@@ -65,7 +65,9 @@ of \code{"pm25"}.}
 \item{x}{Name of variable to plot against wind direction in polar
 coordinates, the default is wind speed, \dQuote{ws}.}
 
-\item{wd}{Name of wind direction field.}
+\item{wd}{The name of the column in \code{mydata} representing the decimal wind
+direction, 0 to 360 where 0/360 are North and 180 is South. Defaults to
+\code{"wd"}.}
 
 \item{type}{Character string(s) defining how data should be split/conditioned
 before plotting. \code{"default"} produces a single panel using the entire
@@ -218,8 +220,8 @@ removing real data points. It is recommended to consider your data with
 care. Also, the \code{polarFreq} function can be of use in such circumstances.}
 
 \item{col.na}{When \code{min.bin} is > 1 it can be useful to show where data are
-removed on the plots. This is done by shading the missing data in
-\code{col.na}. To not highlight missing data when \code{min.bin} > 1 choose \code{col.na = "transparent"}.}
+removed on the plots. This is done by shading the missing data in \code{col.na}.
+To not highlight missing data when \code{min.bin} > 1 choose \code{col.na = "transparent"}.}
 
 \item{upper}{This sets the upper limit wind speed to be used. Often there are
 only a relatively few data points at very high wind speeds and plotting all

--- a/man/pollutionRose.Rd
+++ b/man/pollutionRose.Rd
@@ -59,8 +59,6 @@ to a file).}
 \item{...}{
   Arguments passed on to \code{\link[=windRose]{windRose}}
   \describe{
-    \item{\code{ws}}{Name of the column representing wind speed.}
-    \item{\code{wd}}{Name of the column representing wind direction.}
     \item{\code{ws2,wd2}}{The user can supply a second set of wind speed and wind
 direction values with which the first can be compared. See
 \code{\link[=pollutionRose]{pollutionRose()}} for more details.}
@@ -107,6 +105,11 @@ each bin.}
 printed in each panel together with a description of the statistic below
 the plot. If \code{FALSE} then only the statistic will be printed.}
     \item{\code{border}}{Border colour for shaded areas. Default is no border.}
+    \item{\code{ws}}{The name of the column in \code{mydata} representing the wind speed.
+Defaults to \code{"ws"}.}
+    \item{\code{wd}}{The name of the column in \code{mydata} representing the decimal wind
+direction, 0 to 360 where 0/360 are North and 180 is South. Defaults to
+\code{"wd"}.}
     \item{\code{type}}{Character string(s) defining how data should be split/conditioned
 before plotting. \code{"default"} produces a single panel using the entire
 dataset. Any other options will split the plot into different panels - a

--- a/man/shared_openair_params.Rd
+++ b/man/shared_openair_params.Rd
@@ -4,6 +4,13 @@
 \alias{docs-shared-internal}
 \title{Shared openair parameters}
 \arguments{
+\item{ws}{The name of the column in \code{mydata} representing the wind speed.
+Defaults to \code{"ws"}.}
+
+\item{wd}{The name of the column in \code{mydata} representing the decimal wind
+direction, 0 to 360 where 0/360 are North and 180 is South. Defaults to
+\code{"wd"}.}
+
 \item{type}{Character string(s) defining how data should be split/conditioned
 before plotting. \code{"default"} produces a single panel using the entire
 dataset. Any other options will split the plot into different panels - a

--- a/man/windRose.Rd
+++ b/man/windRose.Rd
@@ -43,9 +43,12 @@ windRose(
 \arguments{
 \item{mydata}{A data frame containing fields \code{ws} and \code{wd}}
 
-\item{ws}{Name of the column representing wind speed.}
+\item{ws}{The name of the column in \code{mydata} representing the wind speed.
+Defaults to \code{"ws"}.}
 
-\item{wd}{Name of the column representing wind direction.}
+\item{wd}{The name of the column in \code{mydata} representing the decimal wind
+direction, 0 to 360 where 0/360 are North and 180 is South. Defaults to
+\code{"wd"}.}
 
 \item{ws2, wd2}{The user can supply a second set of wind speed and wind
 direction values with which the first can be compared. See


### PR DESCRIPTION
`polarPlot()` and `windRose()` have `ws` and `wd` args.

This PR adds these arguments, where relevant, to `polarAnnulus()`, `polarFreq()`, `percentileRose()` and `polarDiff()`.