### PR TITLE
feat: allow scalar `breaks` in functions like `trendLevel()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -48,6 +48,8 @@
 
     - If `breaks` don't cover the full range of the data being binned, the maximum and minimum `breaks` will be overwritten so that it does.
     
+    - If `breaks` is of length `1`, the colour range will be split into `breaks` categories, using the same logic as running `cutData()` on a numeric column.
+    
     - `polarPlot()`, `polarAnnulus()` and `corPlot()` have gained `breaks` and `labels`.
 
 - `smoothTrend()` will now use `loess` when it has insufficient data to fit a GAM.

--- a/R/shared-docs.R
+++ b/R/shared-docs.R
@@ -51,15 +51,25 @@
 #'   override this. For format types see [strptime()]. For example, to format
 #'   the date like "Jan-2012" set `date.format = "\%b-\%Y"`.
 #'
-#' @param breaks,labels If a categorical colour scale is required then `breaks`
-#'   should be specified. These should be provided as a numeric vector, e.g.,
-#'   `breaks = c(0, 50, 100, 1000)`. Users should set the maximum value of
-#'   `breaks` to exceed the maximum data value to ensure it is within the
-#'   maximum final range, e.g., 100--1000 in this case. Labels will
-#'   automatically be generated, but can be customised by passing a character
-#'   vector to `labels`, e.g., `labels = c("good", "bad", "very bad")`. In this
-#'   example, `0 - 50` will be `"good"` and so on. Note there is one less label
-#'   than break.
+#' @param breaks,labels If a categorical colour scale is required, `breaks`
+#'   should be specified. This can be either of:
+#'
+#'   - A single value, which will divide the scale into `breaks` levels using the
+#'   same logic as [cutData()]. For example, `breaks = 5` will split the scale
+#'   into five quantiles.
+#'
+#'   - A numeric vector, which will define the specific breakpoints. For
+#'   example, `c(0, 50, 100)` will bin the data into `0 to 50`, `50 to 100`, and
+#'   so on. If `breaks` does not cover the full range of the data, the outer
+#'   limits will be extended so that the full colour scale is covered while
+#'   retaining the desired number of breaks.
+#'
+#'   By default, `breaks` will generate nicely formatted labels for each
+#'   category. The `labels` argument overrides this - for example, a user could
+#'   define `breaks = 3, labels = c("low", "medium", "high")`. Care should be
+#'   taken to provide the appropriate number of `labels` - it should be equal to
+#'   `breaks` if a single value is given, or equal to `length(breaks)-1` if
+#'   `breaks` is a vector.
 #'
 #' @param x.relation,y.relation This determines how the x- and y-axis scales are
 #'   plotted. `"same"` ensures all panels use the same scale and `"free"` will

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -437,24 +437,29 @@ capture_dots <- function(...) {
 
 # Handle cutting numeric vectors for discretising plots
 cut_plot_breaks <- function(x, breaks, labels) {
-  if (!is.null(breaks)) {
-    categorical <- TRUE
-
-    # ensure breaks covers all data
-    if (max(breaks) < max(x, na.rm = TRUE)) {
-      breaks[length(breaks)] <- ceiling(max(x, na.rm = TRUE))
-    }
-    if (min(breaks) > min(x, na.rm = TRUE)) {
-      breaks[1] <- floor(min(x, na.rm = TRUE))
-    }
-    breaks <- sort(unique(breaks))
-
-    # assign labels if no labels are given
-    labels <- get_labels_from_breaks(breaks, labels)
-
-    x <- cut(x, breaks = breaks, labels = labels, include.lowest = TRUE)
+  if (is.null(breaks)) {
+    return(x)
   }
-  x
+
+  # if only one break, use as number of intervals
+  if (length(breaks) == 1) {
+    return(cutVecNumeric(x = x, type = "", n.levels = breaks, is.axis = FALSE))
+  }
+
+  # assign labels if no labels are given
+  labels <- labels %||% get_labels_from_breaks(breaks, labels)
+
+  # ensure breaks covers all data
+  if (max(breaks) < max(x, na.rm = TRUE)) {
+    breaks[length(breaks)] <- ceiling(max(x, na.rm = TRUE))
+  }
+  if (min(breaks) > min(x, na.rm = TRUE)) {
+    breaks[1] <- floor(min(x, na.rm = TRUE))
+  }
+
+  # cut x into breaks
+  breaks <- sort(unique(breaks))
+  cut(x, breaks = breaks, labels = labels, include.lowest = TRUE)
 }
 
 # Recycle helper

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -443,7 +443,19 @@ cut_plot_breaks <- function(x, breaks, labels) {
 
   # if only one break, use as number of intervals
   if (length(breaks) == 1) {
-    return(cutVecNumeric(x = x, type = "", n.levels = breaks, is.axis = FALSE))
+    x <- cutVecNumeric(x = x, type = "", n.levels = breaks, is.axis = FALSE)
+
+    if (!is.null(labels)) {
+      if (length(labels) != nlevels(x)) {
+        cli::cli_abort(
+          "Length of {.arg labels} ({length(labels)}) \\
+          is not equal to number of categories ({nlevels(x)})."
+        )
+      }
+      levels(x) <- labels
+    }
+
+    return(x)
   }
 
   # assign labels if no labels are given

--- a/man/calendarPlot.Rd
+++ b/man/calendarPlot.Rd
@@ -132,15 +132,25 @@ the text above \code{lim}.}
 \item{digits}{The number of digits used to display concentration values when
 \code{annotate = "value"}.}
 
-\item{breaks, labels}{If a categorical colour scale is required then \code{breaks}
-should be specified. These should be provided as a numeric vector, e.g.,
-\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
-\code{breaks} to exceed the maximum data value to ensure it is within the
-maximum final range, e.g., 100--1000 in this case. Labels will
-automatically be generated, but can be customised by passing a character
-vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
-example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
-than break.}
+\item{breaks, labels}{If a categorical colour scale is required, \code{breaks}
+should be specified. This can be either of:
+\itemize{
+\item A single value, which will divide the scale into \code{breaks} levels using the
+same logic as \code{\link[=cutData]{cutData()}}. For example, \code{breaks = 5} will split the scale
+into five quantiles.
+\item A numeric vector, which will define the specific breakpoints. For
+example, \code{c(0, 50, 100)} will bin the data into \verb{0 to 50}, \verb{50 to 100}, and
+so on. If \code{breaks} does not cover the full range of the data, the outer
+limits will be extended so that the full colour scale is covered while
+retaining the desired number of breaks.
+}
+
+By default, \code{breaks} will generate nicely formatted labels for each
+category. The \code{labels} argument overrides this - for example, a user could
+define \verb{breaks = 3, labels = c("low", "medium", "high")}. Care should be
+taken to provide the appropriate number of \code{labels} - it should be equal to
+\code{breaks} if a single value is given, or equal to \code{length(breaks)-1} if
+\code{breaks} is a vector.}
 
 \item{w.shift}{Controls the order of the days of the week. By default the
 plot shows Saturday first (\code{w.shift = 0}). To change this so that it starts

--- a/man/corPlot.Rd
+++ b/man/corPlot.Rd
@@ -89,15 +89,25 @@ Can be \code{"both"}, \code{"lower"} or \code{"upper"}. Defaults to \code{"both"
 diagonal of a correlation matrix is axiomatically always \code{1} as it
 represents correlating a variable with itself. Defaults to \code{TRUE}.}
 
-\item{breaks, labels}{If a categorical colour scale is required then \code{breaks}
-should be specified. These should be provided as a numeric vector, e.g.,
-\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
-\code{breaks} to exceed the maximum data value to ensure it is within the
-maximum final range, e.g., 100--1000 in this case. Labels will
-automatically be generated, but can be customised by passing a character
-vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
-example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
-than break.}
+\item{breaks, labels}{If a categorical colour scale is required, \code{breaks}
+should be specified. This can be either of:
+\itemize{
+\item A single value, which will divide the scale into \code{breaks} levels using the
+same logic as \code{\link[=cutData]{cutData()}}. For example, \code{breaks = 5} will split the scale
+into five quantiles.
+\item A numeric vector, which will define the specific breakpoints. For
+example, \code{c(0, 50, 100)} will bin the data into \verb{0 to 50}, \verb{50 to 100}, and
+so on. If \code{breaks} does not cover the full range of the data, the outer
+limits will be extended so that the full colour scale is covered while
+retaining the desired number of breaks.
+}
+
+By default, \code{breaks} will generate nicely formatted labels for each
+category. The \code{labels} argument overrides this - for example, a user could
+define \verb{breaks = 3, labels = c("low", "medium", "high")}. Care should be
+taken to provide the appropriate number of \code{labels} - it should be equal to
+\code{breaks} if a single value is given, or equal to \code{length(breaks)-1} if
+\code{breaks} is a vector.}
 
 \item{cols}{Colours to use for plotting. Can be a pre-set palette (e.g.,
 \code{"turbo"}, \code{"viridis"}, \code{"tol"}, \code{"Dark2"}, etc.) or a user-defined vector

--- a/man/polarAnnulus.Rd
+++ b/man/polarAnnulus.Rd
@@ -188,15 +188,25 @@ particularly useful if one is interested in the patterns of concentrations
 for several pollutants on different scales e.g. NOx and CO. Often useful if
 more than one \code{pollutant} is chosen.}
 
-\item{breaks, labels}{If a categorical colour scale is required then \code{breaks}
-should be specified. These should be provided as a numeric vector, e.g.,
-\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
-\code{breaks} to exceed the maximum data value to ensure it is within the
-maximum final range, e.g., 100--1000 in this case. Labels will
-automatically be generated, but can be customised by passing a character
-vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
-example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
-than break.}
+\item{breaks, labels}{If a categorical colour scale is required, \code{breaks}
+should be specified. This can be either of:
+\itemize{
+\item A single value, which will divide the scale into \code{breaks} levels using the
+same logic as \code{\link[=cutData]{cutData()}}. For example, \code{breaks = 5} will split the scale
+into five quantiles.
+\item A numeric vector, which will define the specific breakpoints. For
+example, \code{c(0, 50, 100)} will bin the data into \verb{0 to 50}, \verb{50 to 100}, and
+so on. If \code{breaks} does not cover the full range of the data, the outer
+limits will be extended so that the full colour scale is covered while
+retaining the desired number of breaks.
+}
+
+By default, \code{breaks} will generate nicely formatted labels for each
+category. The \code{labels} argument overrides this - for example, a user could
+define \verb{breaks = 3, labels = c("low", "medium", "high")}. Care should be
+taken to provide the appropriate number of \code{labels} - it should be equal to
+\code{breaks} if a single value is given, or equal to \code{length(breaks)-1} if
+\code{breaks} is a vector.}
 
 \item{strip.position}{Location where the facet 'strips' are located when
 using \code{type}. When one \code{type} is provided, can be one of \code{"left"},

--- a/man/polarCluster.Rd
+++ b/man/polarCluster.Rd
@@ -268,15 +268,25 @@ possible pollutant source is active or not).
 
 Most \code{openair} plotting functions can take two \code{type} arguments. If two are
 given, the first is used for the columns and the second for the rows.}
-    \item{\code{breaks,labels}}{If a categorical colour scale is required then \code{breaks}
-should be specified. These should be provided as a numeric vector, e.g.,
-\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
-\code{breaks} to exceed the maximum data value to ensure it is within the
-maximum final range, e.g., 100--1000 in this case. Labels will
-automatically be generated, but can be customised by passing a character
-vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
-example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
-than break.}
+    \item{\code{breaks,labels}}{If a categorical colour scale is required, \code{breaks}
+should be specified. This can be either of:
+\itemize{
+\item A single value, which will divide the scale into \code{breaks} levels using the
+same logic as \code{\link[=cutData]{cutData()}}. For example, \code{breaks = 5} will split the scale
+into five quantiles.
+\item A numeric vector, which will define the specific breakpoints. For
+example, \code{c(0, 50, 100)} will bin the data into \verb{0 to 50}, \verb{50 to 100}, and
+so on. If \code{breaks} does not cover the full range of the data, the outer
+limits will be extended so that the full colour scale is covered while
+retaining the desired number of breaks.
+}
+
+By default, \code{breaks} will generate nicely formatted labels for each
+category. The \code{labels} argument overrides this - for example, a user could
+define \verb{breaks = 3, labels = c("low", "medium", "high")}. Care should be
+taken to provide the appropriate number of \code{labels} - it should be equal to
+\code{breaks} if a single value is given, or equal to \code{length(breaks)-1} if
+\code{breaks} is a vector.}
     \item{\code{key.position}}{Location where the legend is to be placed. Allowed
 arguments include \code{"top"}, \code{"right"}, \code{"bottom"}, \code{"left"} and \code{"none"},
 the last of which removes the legend entirely.}

--- a/man/polarDiff.Rd
+++ b/man/polarDiff.Rd
@@ -249,15 +249,25 @@ of R colours (e.g., \code{c("yellow", "green", "blue", "black")} - see
 \code{\link[=colours]{colours()}} for a full list) or hex-codes (e.g., \code{c("#30123B", "#9CF649", "#7A0403")}). Alternatively, can be a list of arguments to control the
 colour palette more closely (e.g., \code{palette}, \code{direction}, \code{alpha}, etc.).
 See \code{\link[=openColours]{openColours()}} and \code{\link[=colourOpts]{colourOpts()}} for more details.}
-    \item{\code{breaks,labels}}{If a categorical colour scale is required then \code{breaks}
-should be specified. These should be provided as a numeric vector, e.g.,
-\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
-\code{breaks} to exceed the maximum data value to ensure it is within the
-maximum final range, e.g., 100--1000 in this case. Labels will
-automatically be generated, but can be customised by passing a character
-vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
-example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
-than break.}
+    \item{\code{breaks,labels}}{If a categorical colour scale is required, \code{breaks}
+should be specified. This can be either of:
+\itemize{
+\item A single value, which will divide the scale into \code{breaks} levels using the
+same logic as \code{\link[=cutData]{cutData()}}. For example, \code{breaks = 5} will split the scale
+into five quantiles.
+\item A numeric vector, which will define the specific breakpoints. For
+example, \code{c(0, 50, 100)} will bin the data into \verb{0 to 50}, \verb{50 to 100}, and
+so on. If \code{breaks} does not cover the full range of the data, the outer
+limits will be extended so that the full colour scale is covered while
+retaining the desired number of breaks.
+}
+
+By default, \code{breaks} will generate nicely formatted labels for each
+category. The \code{labels} argument overrides this - for example, a user could
+define \verb{breaks = 3, labels = c("low", "medium", "high")}. Care should be
+taken to provide the appropriate number of \code{labels} - it should be equal to
+\code{breaks} if a single value is given, or equal to \code{length(breaks)-1} if
+\code{breaks} is a vector.}
     \item{\code{angle.scale}}{In radial plots (e.g., \code{\link[=polarPlot]{polarPlot()}}), the radial scale is
 drawn directly on the plot itself. While suitable defaults have been
 chosen, sometimes the placement of the scale may interfere with an

--- a/man/polarFreq.Rd
+++ b/man/polarFreq.Rd
@@ -72,15 +72,25 @@ an interval of 0.5 may be more appropriate.}
 
 \item{limits}{The limits of the colour bar (e.g., \code{c(0, 100)}).}
 
-\item{breaks, labels}{If a categorical colour scale is required then \code{breaks}
-should be specified. These should be provided as a numeric vector, e.g.,
-\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
-\code{breaks} to exceed the maximum data value to ensure it is within the
-maximum final range, e.g., 100--1000 in this case. Labels will
-automatically be generated, but can be customised by passing a character
-vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
-example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
-than break.}
+\item{breaks, labels}{If a categorical colour scale is required, \code{breaks}
+should be specified. This can be either of:
+\itemize{
+\item A single value, which will divide the scale into \code{breaks} levels using the
+same logic as \code{\link[=cutData]{cutData()}}. For example, \code{breaks = 5} will split the scale
+into five quantiles.
+\item A numeric vector, which will define the specific breakpoints. For
+example, \code{c(0, 50, 100)} will bin the data into \verb{0 to 50}, \verb{50 to 100}, and
+so on. If \code{breaks} does not cover the full range of the data, the outer
+limits will be extended so that the full colour scale is covered while
+retaining the desired number of breaks.
+}
+
+By default, \code{breaks} will generate nicely formatted labels for each
+category. The \code{labels} argument overrides this - for example, a user could
+define \verb{breaks = 3, labels = c("low", "medium", "high")}. Care should be
+taken to provide the appropriate number of \code{labels} - it should be equal to
+\code{breaks} if a single value is given, or equal to \code{length(breaks)-1} if
+\code{breaks} is a vector.}
 
 \item{cols}{Colours to use for plotting. Can be a pre-set palette (e.g.,
 \code{"turbo"}, \code{"viridis"}, \code{"tol"}, \code{"Dark2"}, etc.) or a user-defined vector

--- a/man/polarPlot.Rd
+++ b/man/polarPlot.Rd
@@ -266,15 +266,25 @@ particularly useful if one is interested in the patterns of concentrations
 for several pollutants on different scales e.g. NOx and CO. Often useful if
 more than one \code{pollutant} is chosen.}
 
-\item{breaks, labels}{If a categorical colour scale is required then \code{breaks}
-should be specified. These should be provided as a numeric vector, e.g.,
-\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
-\code{breaks} to exceed the maximum data value to ensure it is within the
-maximum final range, e.g., 100--1000 in this case. Labels will
-automatically be generated, but can be customised by passing a character
-vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
-example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
-than break.}
+\item{breaks, labels}{If a categorical colour scale is required, \code{breaks}
+should be specified. This can be either of:
+\itemize{
+\item A single value, which will divide the scale into \code{breaks} levels using the
+same logic as \code{\link[=cutData]{cutData()}}. For example, \code{breaks = 5} will split the scale
+into five quantiles.
+\item A numeric vector, which will define the specific breakpoints. For
+example, \code{c(0, 50, 100)} will bin the data into \verb{0 to 50}, \verb{50 to 100}, and
+so on. If \code{breaks} does not cover the full range of the data, the outer
+limits will be extended so that the full colour scale is covered while
+retaining the desired number of breaks.
+}
+
+By default, \code{breaks} will generate nicely formatted labels for each
+category. The \code{labels} argument overrides this - for example, a user could
+define \verb{breaks = 3, labels = c("low", "medium", "high")}. Care should be
+taken to provide the appropriate number of \code{labels} - it should be equal to
+\code{breaks} if a single value is given, or equal to \code{length(breaks)-1} if
+\code{breaks} is a vector.}
 
 \item{key.title}{Used to set the title of the legend. The legend title is
 passed to \code{\link[=quickText]{quickText()}} if \code{auto.text = TRUE}.}

--- a/man/shared_openair_params.Rd
+++ b/man/shared_openair_params.Rd
@@ -50,15 +50,25 @@ sensible format is chosen by default, but the user can set \code{date.format} to
 override this. For format types see \code{\link[=strptime]{strptime()}}. For example, to format
 the date like "Jan-2012" set \code{date.format = "\\\%b-\\\%Y"}.}
 
-\item{breaks, labels}{If a categorical colour scale is required then \code{breaks}
-should be specified. These should be provided as a numeric vector, e.g.,
-\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
-\code{breaks} to exceed the maximum data value to ensure it is within the
-maximum final range, e.g., 100--1000 in this case. Labels will
-automatically be generated, but can be customised by passing a character
-vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
-example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
-than break.}
+\item{breaks, labels}{If a categorical colour scale is required, \code{breaks}
+should be specified. This can be either of:
+\itemize{
+\item A single value, which will divide the scale into \code{breaks} levels using the
+same logic as \code{\link[=cutData]{cutData()}}. For example, \code{breaks = 5} will split the scale
+into five quantiles.
+\item A numeric vector, which will define the specific breakpoints. For
+example, \code{c(0, 50, 100)} will bin the data into \verb{0 to 50}, \verb{50 to 100}, and
+so on. If \code{breaks} does not cover the full range of the data, the outer
+limits will be extended so that the full colour scale is covered while
+retaining the desired number of breaks.
+}
+
+By default, \code{breaks} will generate nicely formatted labels for each
+category. The \code{labels} argument overrides this - for example, a user could
+define \verb{breaks = 3, labels = c("low", "medium", "high")}. Care should be
+taken to provide the appropriate number of \code{labels} - it should be equal to
+\code{breaks} if a single value is given, or equal to \code{length(breaks)-1} if
+\code{breaks} is a vector.}
 
 \item{x.relation, y.relation}{This determines how the x- and y-axis scales are
 plotted. \code{"same"} ensures all panels use the same scale and \code{"free"} will

--- a/man/trendLevel.Rd
+++ b/man/trendLevel.Rd
@@ -97,15 +97,25 @@ argument defines whether the strips are "switched" and can take either
 \code{"x"}, \code{"y"}, or \code{"both"}. For example, \code{"x"} will switch the 'top' strip
 locations to the bottom of the plot.}
 
-\item{breaks, labels}{If a categorical colour scale is required then \code{breaks}
-should be specified. These should be provided as a numeric vector, e.g.,
-\code{breaks = c(0, 50, 100, 1000)}. Users should set the maximum value of
-\code{breaks} to exceed the maximum data value to ensure it is within the
-maximum final range, e.g., 100--1000 in this case. Labels will
-automatically be generated, but can be customised by passing a character
-vector to \code{labels}, e.g., \code{labels = c("good", "bad", "very bad")}. In this
-example, \code{0 - 50} will be \code{"good"} and so on. Note there is one less label
-than break.}
+\item{breaks, labels}{If a categorical colour scale is required, \code{breaks}
+should be specified. This can be either of:
+\itemize{
+\item A single value, which will divide the scale into \code{breaks} levels using the
+same logic as \code{\link[=cutData]{cutData()}}. For example, \code{breaks = 5} will split the scale
+into five quantiles.
+\item A numeric vector, which will define the specific breakpoints. For
+example, \code{c(0, 50, 100)} will bin the data into \verb{0 to 50}, \verb{50 to 100}, and
+so on. If \code{breaks} does not cover the full range of the data, the outer
+limits will be extended so that the full colour scale is covered while
+retaining the desired number of breaks.
+}
+
+By default, \code{breaks} will generate nicely formatted labels for each
+category. The \code{labels} argument overrides this - for example, a user could
+define \verb{breaks = 3, labels = c("low", "medium", "high")}. Care should be
+taken to provide the appropriate number of \code{labels} - it should be equal to
+\code{breaks} if a single value is given, or equal to \code{length(breaks)-1} if
+\code{breaks} is a vector.}
 
 \item{statistic}{The statistic to apply when aggregating the data; default is
 the mean. Can be one of \code{"mean"}, \code{"max"}, \code{"min"}, \code{"median"},


### PR DESCRIPTION
This PR allows `breaks` in `breaks`/`labels` functions to be a single value. Previously a single value would cause an error.

A scalar `breaks` value is passed to `cutData()`.

`labels` is still honoured. Documentation has also been updated.

```r
polarPlot(mydata, "no2", breaks = 10)
```

<img width="987" height="586" alt="image" src="https://github.com/user-attachments/assets/d7ef51ac-2ba8-4c7d-ba27-3f7729ca67e2" />
