### PR TITLE
feat: add saturation/lightness to `openColours()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -38,7 +38,7 @@
 
 - Refinements to colours in `{openair}`:
 
-    - `openColours()` gains `direction`, `alpha`, `begin` and `end` for better control over colour palettes.
+    - `openColours()` gains `direction`, `alpha`, `begin`, `end`, `brightness` and `saturation` for better control over colour palettes.
     
     - Added `colourOpts()`. Any `cols` argument in `{openair}` can now take the `colourOpts()` function, which tells each plotting function how to use the new `openColours()` arguments.
     
@@ -46,7 +46,7 @@
 
     - New palettes:
 
-        - Completed the set of "viridis" palettes with "rocket" and "mako".
+        - Completed the set of "viridis" palettes with `"rocket"` and `"mako"`.
 
         - Added additional palettes by Paul Tol; `"tol.highcontrast"`, `"tol.vibrant"`, `"tol.mediumcontrast"`, `"tol.pale"` and `"tol.dark"`.
     

--- a/NEWS.md
+++ b/NEWS.md
@@ -38,7 +38,7 @@
 
 - Refinements to colours in `{openair}`:
 
-    - `openColours()` gains `direction`, `alpha`, `begin`, `end`, `brightness` and `saturation` for better control over colour palettes.
+    - `openColours()` gains `direction`, `alpha`, `begin`, `end`, `lightness` and `saturation` for better control over colour palettes.
     
     - Added `colourOpts()`. Any `cols` argument in `{openair}` can now take the `colourOpts()` function, which tells each plotting function how to use the new `openColours()` arguments.
     

--- a/R/colourOpts.R
+++ b/R/colourOpts.R
@@ -8,6 +8,7 @@
 #' `colourOpts()` and `colorOpts()` are synonyms.
 #'
 #' @inheritParams openColours
+#' @family colour functions
 #'
 #' @export
 #' @return A list of options that can be passed to the `cols` argument of
@@ -24,20 +25,18 @@ colourOpts <- function(
   alpha = 1,
   begin = 0,
   end = 1,
-  direction = 1
+  direction = 1,
+  brightness = 0.5,
+  saturation = 0.5
 ) {
-  fix_01 <- function(x) {
-    x[x < 0] <- 0
-    x[x > 1] <- 1
-    x
-  }
-
   list(
     scheme = scheme,
-    alpha = fix_01(alpha),
-    begin = fix_01(begin),
-    end = fix_01(end),
-    direction = sign(direction)
+    alpha = alpha,
+    begin = begin,
+    end = end,
+    direction = direction,
+    brightness = brightness,
+    saturation = saturation
   )
 }
 
@@ -68,6 +67,8 @@ resolve_colour_opts <- function(x, n, ...) {
     alpha = x$alpha %||% defaults$alpha,
     begin = x$begin %||% defaults$begin,
     end = x$end %||% defaults$end,
-    direction = x$direction %||% defaults$direction
+    direction = x$direction %||% defaults$direction,
+    brightness = x$brightness %||% defaults$brightness,
+    saturation = x$saturation %||% defaults$saturation
   )
 }

--- a/R/colourOpts.R
+++ b/R/colourOpts.R
@@ -26,8 +26,8 @@ colourOpts <- function(
   begin = 0,
   end = 1,
   direction = 1,
-  brightness = 0.5,
-  saturation = 0.5
+  saturation = 0.5,
+  lightness = 0.5
 ) {
   list(
     scheme = scheme,
@@ -35,8 +35,8 @@ colourOpts <- function(
     begin = begin,
     end = end,
     direction = direction,
-    brightness = brightness,
-    saturation = saturation
+    saturation = saturation,
+    lightness = lightness
   )
 }
 
@@ -68,7 +68,7 @@ resolve_colour_opts <- function(x, n, ...) {
     begin = x$begin %||% defaults$begin,
     end = x$end %||% defaults$end,
     direction = x$direction %||% defaults$direction,
-    brightness = x$brightness %||% defaults$brightness,
+    lightness = x$lightness %||% defaults$lightness,
     saturation = x$saturation %||% defaults$saturation
   )
 }

--- a/R/openColours.R
+++ b/R/openColours.R
@@ -205,9 +205,9 @@
 #' @param direction The order of the colours. `1` is the default and gives the
 #'   normal order. `-1` will reverse the order of the colours.
 #'
-#' @param brightness The brightness of the colours, between `0` (completely
+#' @param lightness The lightness of the colours, between `0` (completely
 #'   black) and `1` (completely white). The default is `0.5`, which gives the
-#'   original brightness of the colours. Values less than `0.5` will make the
+#'   original lightness of the colours. Values less than `0.5` will make the
 #'   colours darker, and values greater than `0.5` will make the colours
 #'   brighter.
 #'
@@ -253,8 +253,8 @@ openColours <- function(
   begin = 0,
   end = 1,
   direction = 1,
-  brightness = 0.5,
-  saturation = 0.5
+  saturation = 0.5,
+  lightness = 0.5
 ) {
   # standardise inputs
   fix_01 <- function(x) {
@@ -265,7 +265,7 @@ openColours <- function(
   alpha <- fix_01(alpha)
   begin <- fix_01(begin)
   end <- fix_01(end)
-  brightness <- fix_01(brightness)
+  lightness <- fix_01(lightness)
   saturation <- fix_01(saturation)
   direction <- sign(direction)
   direction[direction == 0] <- 1
@@ -295,7 +295,7 @@ openColours <- function(
     idx <- round(1 + (length(cols) - 1) * c(begin, end))
     cols <- cols[idx[1]:idx[2]]
     cols <- grDevices::colorRampPalette(cols)(n %||% 100L)
-    return(.finalise(cols, direction, alpha, brightness, saturation))
+    return(.finalise(cols, direction, alpha, lightness, saturation))
   }
 
   # single named scheme
@@ -315,13 +315,13 @@ openColours <- function(
       begin,
       end,
       alpha,
-      brightness,
+      lightness,
       saturation
     )
   } else if (scheme == "hue") {
-    .huePalette(n_out, direction, begin, end, alpha, brightness, saturation)
+    .huePalette(n_out, direction, begin, end, alpha, lightness, saturation)
   } else if (scheme == "greyscale") {
-    .greyPalette(n_out, direction, begin, end, alpha, brightness, saturation)
+    .greyPalette(n_out, direction, begin, end, alpha, lightness, saturation)
   } else if (scheme %in% c(.div_schemes, .seq_schemes)) {
     .seqPalette(
       n_out,
@@ -330,11 +330,11 @@ openColours <- function(
       begin,
       end,
       alpha,
-      brightness,
+      lightness,
       saturation
     )
   } else if (scheme %in% names(.qual_schemes)) {
-    .qualPalette(n_out, scheme, direction, alpha, brightness, saturation)
+    .qualPalette(n_out, scheme, direction, alpha, lightness, saturation)
   }
 
   cols
@@ -425,22 +425,22 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
 
 #' Apply direction and alpha to a colour vector
 #' @noRd
-.finalise <- function(cols, direction, alpha, brightness, saturation) {
+.finalise <- function(cols, direction, alpha, lightness, saturation) {
   if (direction == -1) {
     cols <- rev(cols)
   }
   cols <- substr(cols, 1, 7)
   cols <- paste0(cols, sprintf("%02X", round(alpha * 255)))
-  cols <- .adjust_brightness(cols, brightness)
+  cols <- .adjust_lightness(cols, lightness)
   cols <- .adjust_saturation(cols, saturation)
   cols
 }
 
-#' Adjust the brightness of a colour vector
+#' Adjust the lightness of a colour vector
 #' @noRd
-.adjust_brightness <- function(color, brightness = 0.5) {
+.adjust_lightness <- function(color, lightness = 0.5) {
   # standardise to -1 to 1
-  factor <- (brightness - 0.5) * 2
+  factor <- (lightness - 0.5) * 2
 
   rgba_vals <- grDevices::col2rgb(color, alpha = TRUE) / 255
   rgb_vals <- rgba_vals[1:3, , drop = FALSE]
@@ -509,7 +509,7 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
   begin,
   end,
   alpha,
-  brightness,
+  lightness,
   saturation
 ) {
   max_n <- maxcolors[[scheme]]
@@ -538,7 +538,7 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
       substr(base_cols, 1, 7),
       interpolate = "spline"
     )(n)
-    .finalise(cols, direction = 1L, alpha = alpha, brightness, saturation)
+    .finalise(cols, direction = 1L, alpha = alpha, lightness, saturation)
   }
 }
 
@@ -550,7 +550,7 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
   begin,
   end,
   alpha,
-  brightness,
+  lightness,
   saturation
 ) {
   h <- c(0, 360) + 15
@@ -563,7 +563,7 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
     c = 100,
     l = 65
   )
-  .finalise(cols, direction, alpha, brightness, saturation)
+  .finalise(cols, direction, alpha, lightness, saturation)
 }
 
 #' Greyscale palette
@@ -574,7 +574,7 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
   begin,
   end,
   alpha,
-  brightness,
+  lightness,
   saturation
 ) {
   # default begin/end for greyscale avoids pure black/white
@@ -585,7 +585,7 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
     end <- 0.9
   }
   cols <- grDevices::grey(seq(end, begin, length.out = n))
-  .finalise(cols, direction, alpha, brightness, saturation)
+  .finalise(cols, direction, alpha, lightness, saturation)
 }
 
 #' Sequential palettes
@@ -597,7 +597,7 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
   begin,
   end,
   alpha,
-  brightness,
+  lightness,
   saturation
 ) {
   interpolate <- "linear"
@@ -1191,12 +1191,12 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
   cols <- cols[idx[1]:idx[2]]
 
   cols <- grDevices::colorRampPalette(cols, interpolate = interpolate)(n)
-  .finalise(cols, direction, alpha, brightness, saturation)
+  .finalise(cols, direction, alpha, lightness, saturation)
 }
 
 #' Qualitative palettes
 #' @noRd
-.qualPalette <- function(n, scheme, direction, alpha, brightness, saturation) {
+.qualPalette <- function(n, scheme, direction, alpha, lightness, saturation) {
   cols <- switch(
     scheme,
     cbPalette = c(
@@ -1365,5 +1365,5 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
   }
 
   # finalise with direction = 1 as already handled above
-  .finalise(cols[1:n], direction = 1, alpha, brightness, saturation)
+  .finalise(cols[1:n], direction = 1, alpha, lightness, saturation)
 }

--- a/R/openColours.R
+++ b/R/openColours.R
@@ -188,7 +188,7 @@
 #'
 #' @param scheme Any one of the pre-defined `openair` schemes (e.g.,
 #'   `"increment"`) or a user-defined palette (e.g., `c("red", "orange",
-#'   "gold")`). See [openColours()] for a full list of available schemes.
+#'   "gold")`). Use [openSchemes()] for a full list of available schemes.
 #'
 #' @param n The whole number of colours required. If not provided, sequential
 #'   palettes will return `100` colours and qualitative palettes will return the
@@ -205,10 +205,23 @@
 #' @param direction The order of the colours. `1` is the default and gives the
 #'   normal order. `-1` will reverse the order of the colours.
 #'
+#' @param brightness The brightness of the colours, between `0` (completely
+#'   black) and `1` (completely white). The default is `0.5`, which gives the
+#'   original brightness of the colours. Values less than `0.5` will make the
+#'   colours darker, and values greater than `0.5` will make the colours
+#'   brighter.
+#'
+#' @param saturation The saturation of the colours, between `0` (completely
+#'   desaturated, i.e., grey) and `1` (completely saturated). The default is
+#'   `0.5`, which gives the original saturation of the colours. Values less than
+#'   `0.5` will make the colours more desaturated (greyer), and values greater
+#'   than `0.5` will make the colours more saturated (vibrant).
+#'
 #' @export
 #'
 #' @return A character vector of hex codes
 #'
+#' @family colour functions
 #' @author David Carslaw
 #' @author Jack Davison
 #'
@@ -239,21 +252,23 @@ openColours <- function(
   alpha = 1,
   begin = 0,
   end = 1,
-  direction = 1
+  direction = 1,
+  brightness = 0.5,
+  saturation = 0.5
 ) {
-  if (alpha < 0 || alpha > 1) {
-    cli::cli_abort("{.arg alpha} must be between `0` and `1`.")
+  # standardise inputs
+  fix_01 <- function(x) {
+    x[x < 0] <- 0
+    x[x > 1] <- 1
+    x
   }
-  if (!direction %in% c(1, -1)) {
-    cli::cli_abort(
-      "{.arg direction} must be either `1` (normal order) or `-1` (reverse order)."
-    )
-  }
-  if (begin < 0 || begin > 1 || end < 0 || end > 1 || begin >= end) {
-    cli::cli_abort(
-      "{.arg begin} and {.arg end} must be between `0` and `1`, and {.arg begin} must be less than {.arg end}."
-    )
-  }
+  alpha <- fix_01(alpha)
+  begin <- fix_01(begin)
+  end <- fix_01(end)
+  brightness <- fix_01(brightness)
+  saturation <- fix_01(saturation)
+  direction <- sign(direction)
+  direction[direction == 0] <- 1
 
   # user-supplied colour vectors
   if (length(scheme) > 1L || !scheme %in% .all_schemes) {
@@ -280,7 +295,7 @@ openColours <- function(
     idx <- round(1 + (length(cols) - 1) * c(begin, end))
     cols <- cols[idx[1]:idx[2]]
     cols <- grDevices::colorRampPalette(cols)(n %||% 100L)
-    return(.finalise(cols, direction, alpha))
+    return(.finalise(cols, direction, alpha, brightness, saturation))
   }
 
   # single named scheme
@@ -293,15 +308,33 @@ openColours <- function(
   }
 
   cols <- if (scheme %in% .brewer_schemes) {
-    .brewerPalette(n_out, scheme, direction, begin, end, alpha)
+    .brewerPalette(
+      n_out,
+      scheme,
+      direction,
+      begin,
+      end,
+      alpha,
+      brightness,
+      saturation
+    )
   } else if (scheme == "hue") {
-    .huePalette(n_out, direction, begin, end, alpha)
+    .huePalette(n_out, direction, begin, end, alpha, brightness, saturation)
   } else if (scheme == "greyscale") {
-    .greyPalette(n_out, direction, begin, end, alpha)
+    .greyPalette(n_out, direction, begin, end, alpha, brightness, saturation)
   } else if (scheme %in% c(.div_schemes, .seq_schemes)) {
-    .seqPalette(n_out, scheme, direction, begin, end, alpha)
+    .seqPalette(
+      n_out,
+      scheme,
+      direction,
+      begin,
+      end,
+      alpha,
+      brightness,
+      saturation
+    )
   } else if (scheme %in% names(.qual_schemes)) {
-    .qualPalette(n_out, scheme, direction, alpha)
+    .qualPalette(n_out, scheme, direction, alpha, brightness, saturation)
   }
 
   cols
@@ -330,6 +363,7 @@ openColors <- openColours
 #'   sequential and diverging schemes can be interpolated to any number of
 #'   colours.
 #'
+#' @family colour functions
 #' @author Jack Davison
 #'
 #' @export
@@ -391,12 +425,71 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
 
 #' Apply direction and alpha to a colour vector
 #' @noRd
-.finalise <- function(cols, direction, alpha) {
+.finalise <- function(cols, direction, alpha, brightness, saturation) {
   if (direction == -1) {
     cols <- rev(cols)
   }
   cols <- substr(cols, 1, 7)
-  paste0(cols, sprintf("%02X", round(alpha * 255)))
+  cols <- paste0(cols, sprintf("%02X", round(alpha * 255)))
+  cols <- .adjust_brightness(cols, brightness)
+  cols <- .adjust_saturation(cols, saturation)
+  cols
+}
+
+#' Adjust the brightness of a colour vector
+#' @noRd
+.adjust_brightness <- function(color, brightness = 0.5) {
+  # standardise to -1 to 1
+  factor <- (brightness - 0.5) * 2
+
+  rgba_vals <- grDevices::col2rgb(color, alpha = TRUE) / 255
+  rgb_vals <- rgba_vals[1:3, , drop = FALSE]
+  alpha <- rgba_vals[4, ]
+
+  if (factor > 0) {
+    new_rgb <- rgb_vals + (1 - rgb_vals) * factor
+  } else if (factor < 0) {
+    new_rgb <- rgb_vals * (1 + factor)
+  } else {
+    new_rgb <- rgb_vals
+  }
+
+  grDevices::rgb(new_rgb[1, ], new_rgb[2, ], new_rgb[3, ], alpha = alpha)
+}
+
+#' Adjust the saturation of a colour vector
+#' @noRd
+.adjust_saturation <- function(color, saturation = 0.5) {
+  factor <- (saturation - 0.5) * 2
+
+  rgba_vals <- grDevices::col2rgb(color, alpha = TRUE) / 255
+  rgb_vals <- rgba_vals[1:3, , drop = FALSE]
+  alpha <- rgba_vals[4, ]
+
+  # Greyscale luminance of the colour (the target for desaturation)
+  luminance <- unname(
+    0.2126 *
+      rgb_vals[1, ] +
+      0.7152 * rgb_vals[2, ] +
+      0.0722 * rgb_vals[3, ]
+  )
+
+  grey <- matrix(luminance, nrow = 3, ncol = length(luminance), byrow = TRUE)
+
+  if (factor > 0) {
+    # Blend away from greyscale toward original (or beyond)
+    new_rgb <- rgb_vals + (rgb_vals - grey) * factor
+  } else if (factor < 0) {
+    # Blend toward greyscale
+    new_rgb <- rgb_vals + (rgb_vals - grey) * factor
+  } else {
+    new_rgb <- rgb_vals
+  }
+
+  # Clamp — unlike lightness, saturation can push values out of range
+  new_rgb[] <- pmax(0, pmin(1, new_rgb))
+
+  grDevices::rgb(new_rgb[1, ], new_rgb[2, ], new_rgb[3, ], alpha = alpha)
 }
 
 #' Check whether strings are valid R colours
@@ -409,7 +502,16 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
 
 #' Brewer palette dispatcher
 #' @noRd
-.brewerPalette <- function(n, scheme, direction, begin, end, alpha) {
+.brewerPalette <- function(
+  n,
+  scheme,
+  direction,
+  begin,
+  end,
+  alpha,
+  brightness,
+  saturation
+) {
   max_n <- maxcolors[[scheme]]
   if (n >= 3L && n <= max_n) {
     brewer.pal(
@@ -436,13 +538,21 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
       substr(base_cols, 1, 7),
       interpolate = "spline"
     )(n)
-    .finalise(cols, direction = 1L, alpha = alpha)
+    .finalise(cols, direction = 1L, alpha = alpha, brightness, saturation)
   }
 }
 
 #' Hue palette
 #' @noRd
-.huePalette <- function(n, direction, begin, end, alpha) {
+.huePalette <- function(
+  n,
+  direction,
+  begin,
+  end,
+  alpha,
+  brightness,
+  saturation
+) {
   h <- c(0, 360) + 15
   if ((diff(h) %% 360) < 1) {
     h[2] <- h[2] - 360 / n
@@ -453,12 +563,20 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
     c = 100,
     l = 65
   )
-  .finalise(cols, direction, alpha)
+  .finalise(cols, direction, alpha, brightness, saturation)
 }
 
 #' Greyscale palette
 #' @noRd
-.greyPalette <- function(n, direction, begin, end, alpha) {
+.greyPalette <- function(
+  n,
+  direction,
+  begin,
+  end,
+  alpha,
+  brightness,
+  saturation
+) {
   # default begin/end for greyscale avoids pure black/white
   if (begin == 0) {
     begin <- 0.1
@@ -467,12 +585,21 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
     end <- 0.9
   }
   cols <- grDevices::grey(seq(end, begin, length.out = n))
-  .finalise(cols, direction, alpha)
+  .finalise(cols, direction, alpha, brightness, saturation)
 }
 
 #' Sequential palettes
 #' @noRd
-.seqPalette <- function(n, scheme, direction, begin, end, alpha) {
+.seqPalette <- function(
+  n,
+  scheme,
+  direction,
+  begin,
+  end,
+  alpha,
+  brightness,
+  saturation
+) {
   interpolate <- "linear"
 
   cols <- switch(
@@ -1064,12 +1191,12 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
   cols <- cols[idx[1]:idx[2]]
 
   cols <- grDevices::colorRampPalette(cols, interpolate = interpolate)(n)
-  .finalise(cols, direction, alpha)
+  .finalise(cols, direction, alpha, brightness, saturation)
 }
 
 #' Qualitative palettes
 #' @noRd
-.qualPalette <- function(n, scheme, direction, alpha) {
+.qualPalette <- function(n, scheme, direction, alpha, brightness, saturation) {
   cols <- switch(
     scheme,
     cbPalette = c(
@@ -1238,5 +1365,5 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
   }
 
   # finalise with direction = 1 as already handled above
-  .finalise(cols[1:n], direction = 1, alpha)
+  .finalise(cols[1:n], direction = 1, alpha, brightness, saturation)
 }

--- a/R/openColours.R
+++ b/R/openColours.R
@@ -439,6 +439,10 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
 #' Adjust the lightness of a colour vector
 #' @noRd
 .adjust_lightness <- function(color, lightness = 0.5) {
+  if (lightness == 0.5) {
+    return(color)
+  }
+
   # standardise to -1 to 1
   factor <- (lightness - 0.5) * 2
 
@@ -460,6 +464,10 @@ openSchemes <- function(palette_type = c("seq", "div", "qual"), n = NULL) {
 #' Adjust the saturation of a colour vector
 #' @noRd
 .adjust_saturation <- function(color, saturation = 0.5) {
+  if (saturation == 0.5) {
+    return(color)
+  }
+
   factor <- (saturation - 0.5) * 2
 
   rgba_vals <- grDevices::col2rgb(color, alpha = TRUE) / 255

--- a/R/percentileRose.R
+++ b/R/percentileRose.R
@@ -117,7 +117,7 @@ percentileRose <- function(
   angle = 10,
   mean = TRUE,
   mean.lty = 1,
-  mean.lwd = 3,
+  mean.lwd = 1,
   mean.col = "grey",
   fill = TRUE,
   intervals = NULL,

--- a/man/colourOpts.Rd
+++ b/man/colourOpts.Rd
@@ -11,8 +11,8 @@ colourOpts(
   begin = 0,
   end = 1,
   direction = 1,
-  brightness = 0.5,
-  saturation = 0.5
+  saturation = 0.5,
+  lightness = 0.5
 )
 
 colorOpts(
@@ -21,8 +21,8 @@ colorOpts(
   begin = 0,
   end = 1,
   direction = 1,
-  brightness = 0.5,
-  saturation = 0.5
+  saturation = 0.5,
+  lightness = 0.5
 )
 }
 \arguments{
@@ -40,17 +40,17 @@ for avoiding very light or dark colours at the ends of schemes.}
 \item{direction}{The order of the colours. \code{1} is the default and gives the
 normal order. \code{-1} will reverse the order of the colours.}
 
-\item{brightness}{The brightness of the colours, between \code{0} (completely
-black) and \code{1} (completely white). The default is \code{0.5}, which gives the
-original brightness of the colours. Values less than \code{0.5} will make the
-colours darker, and values greater than \code{0.5} will make the colours
-brighter.}
-
 \item{saturation}{The saturation of the colours, between \code{0} (completely
 desaturated, i.e., grey) and \code{1} (completely saturated). The default is
 \code{0.5}, which gives the original saturation of the colours. Values less than
 \code{0.5} will make the colours more desaturated (greyer), and values greater
 than \code{0.5} will make the colours more saturated (vibrant).}
+
+\item{lightness}{The lightness of the colours, between \code{0} (completely
+black) and \code{1} (completely white). The default is \code{0.5}, which gives the
+original lightness of the colours. Values less than \code{0.5} will make the
+colours darker, and values greater than \code{0.5} will make the colours
+brighter.}
 }
 \value{
 A list of options that can be passed to the \code{cols} argument of

--- a/man/colourOpts.Rd
+++ b/man/colourOpts.Rd
@@ -5,13 +5,29 @@
 \alias{colorOpts}
 \title{Define \code{cols} options for \code{openair} plots}
 \usage{
-colourOpts(scheme = "default", alpha = 1, begin = 0, end = 1, direction = 1)
+colourOpts(
+  scheme = "default",
+  alpha = 1,
+  begin = 0,
+  end = 1,
+  direction = 1,
+  brightness = 0.5,
+  saturation = 0.5
+)
 
-colorOpts(scheme = "default", alpha = 1, begin = 0, end = 1, direction = 1)
+colorOpts(
+  scheme = "default",
+  alpha = 1,
+  begin = 0,
+  end = 1,
+  direction = 1,
+  brightness = 0.5,
+  saturation = 0.5
+)
 }
 \arguments{
 \item{scheme}{Any one of the pre-defined \code{openair} schemes (e.g.,
-\code{"increment"}) or a user-defined palette (e.g., \code{c("red", "orange", "gold")}). See \code{\link[=openColours]{openColours()}} for a full list of available schemes.}
+\code{"increment"}) or a user-defined palette (e.g., \code{c("red", "orange", "gold")}). Use \code{\link[=openSchemes]{openSchemes()}} for a full list of available schemes.}
 
 \item{alpha}{The alpha transparency level (between \code{0} and \code{1}) for the
 colours. \code{0} is fully transparent, and \code{1} is fully opaque.}
@@ -23,6 +39,18 @@ for avoiding very light or dark colours at the ends of schemes.}
 
 \item{direction}{The order of the colours. \code{1} is the default and gives the
 normal order. \code{-1} will reverse the order of the colours.}
+
+\item{brightness}{The brightness of the colours, between \code{0} (completely
+black) and \code{1} (completely white). The default is \code{0.5}, which gives the
+original brightness of the colours. Values less than \code{0.5} will make the
+colours darker, and values greater than \code{0.5} will make the colours
+brighter.}
+
+\item{saturation}{The saturation of the colours, between \code{0} (completely
+desaturated, i.e., grey) and \code{1} (completely saturated). The default is
+\code{0.5}, which gives the original saturation of the colours. Values less than
+\code{0.5} will make the colours more desaturated (greyer), and values greater
+than \code{0.5} will make the colours more saturated (vibrant).}
 }
 \value{
 A list of options that can be passed to the \code{cols} argument of
@@ -43,3 +71,9 @@ trendLevel(
   cols = colourOpts("viridis", direction = 1, alpha = 0.5)
 )
 }
+\seealso{
+Other colour functions: 
+\code{\link{openColours}()},
+\code{\link{openSchemes}()}
+}
+\concept{colour functions}

--- a/man/openColours.Rd
+++ b/man/openColours.Rd
@@ -11,7 +11,9 @@ openColours(
   alpha = 1,
   begin = 0,
   end = 1,
-  direction = 1
+  direction = 1,
+  brightness = 0.5,
+  saturation = 0.5
 )
 
 openColors(
@@ -20,12 +22,14 @@ openColors(
   alpha = 1,
   begin = 0,
   end = 1,
-  direction = 1
+  direction = 1,
+  brightness = 0.5,
+  saturation = 0.5
 )
 }
 \arguments{
 \item{scheme}{Any one of the pre-defined \code{openair} schemes (e.g.,
-\code{"increment"}) or a user-defined palette (e.g., \code{c("red", "orange", "gold")}). See \code{\link[=openColours]{openColours()}} for a full list of available schemes.}
+\code{"increment"}) or a user-defined palette (e.g., \code{c("red", "orange", "gold")}). Use \code{\link[=openSchemes]{openSchemes()}} for a full list of available schemes.}
 
 \item{n}{The whole number of colours required. If not provided, sequential
 palettes will return \code{100} colours and qualitative palettes will return the
@@ -41,6 +45,18 @@ for avoiding very light or dark colours at the ends of schemes.}
 
 \item{direction}{The order of the colours. \code{1} is the default and gives the
 normal order. \code{-1} will reverse the order of the colours.}
+
+\item{brightness}{The brightness of the colours, between \code{0} (completely
+black) and \code{1} (completely white). The default is \code{0.5}, which gives the
+original brightness of the colours. Values less than \code{0.5} will make the
+colours darker, and values greater than \code{0.5} will make the colours
+brighter.}
+
+\item{saturation}{The saturation of the colours, between \code{0} (completely
+desaturated, i.e., grey) and \code{1} (completely saturated). The default is
+\code{0.5}, which gives the original saturation of the colours. Values less than
+\code{0.5} will make the colours more desaturated (greyer), and values greater
+than \code{0.5} will make the colours more saturated (vibrant).}
 }
 \value{
 A character vector of hex codes
@@ -162,8 +178,14 @@ UK Government Analysis Function:
 Fabio Crameri's Color Schemes: Crameri, F. 2023. Scientific Colour Maps
 (version 8.0.1). Zenodo. DOI: \doi{doi:10.5281/zenodo.1243862}.
 }
+\seealso{
+Other colour functions: 
+\code{\link{colourOpts}()},
+\code{\link{openSchemes}()}
+}
 \author{
 David Carslaw
 
 Jack Davison
 }
+\concept{colour functions}

--- a/man/openColours.Rd
+++ b/man/openColours.Rd
@@ -12,8 +12,8 @@ openColours(
   begin = 0,
   end = 1,
   direction = 1,
-  brightness = 0.5,
-  saturation = 0.5
+  saturation = 0.5,
+  lightness = 0.5
 )
 
 openColors(
@@ -23,8 +23,8 @@ openColors(
   begin = 0,
   end = 1,
   direction = 1,
-  brightness = 0.5,
-  saturation = 0.5
+  saturation = 0.5,
+  lightness = 0.5
 )
 }
 \arguments{
@@ -46,17 +46,17 @@ for avoiding very light or dark colours at the ends of schemes.}
 \item{direction}{The order of the colours. \code{1} is the default and gives the
 normal order. \code{-1} will reverse the order of the colours.}
 
-\item{brightness}{The brightness of the colours, between \code{0} (completely
-black) and \code{1} (completely white). The default is \code{0.5}, which gives the
-original brightness of the colours. Values less than \code{0.5} will make the
-colours darker, and values greater than \code{0.5} will make the colours
-brighter.}
-
 \item{saturation}{The saturation of the colours, between \code{0} (completely
 desaturated, i.e., grey) and \code{1} (completely saturated). The default is
 \code{0.5}, which gives the original saturation of the colours. Values less than
 \code{0.5} will make the colours more desaturated (greyer), and values greater
 than \code{0.5} will make the colours more saturated (vibrant).}
+
+\item{lightness}{The lightness of the colours, between \code{0} (completely
+black) and \code{1} (completely white). The default is \code{0.5}, which gives the
+original lightness of the colours. Values less than \code{0.5} will make the
+colours darker, and values greater than \code{0.5} will make the colours
+brighter.}
 }
 \value{
 A character vector of hex codes

--- a/man/openSchemes.Rd
+++ b/man/openSchemes.Rd
@@ -25,6 +25,12 @@ number of colours available for that scheme (where applicable). This can be
 useful for users to explore the available schemes and to check which schemes
 can provide a certain number of colours.
 }
+\seealso{
+Other colour functions: 
+\code{\link{colourOpts}()},
+\code{\link{openColours}()}
+}
 \author{
 Jack Davison
 }
+\concept{colour functions}

--- a/man/percentileRose.Rd
+++ b/man/percentileRose.Rd
@@ -17,7 +17,7 @@ percentileRose(
   angle = 10,
   mean = TRUE,
   mean.lty = 1,
-  mean.lwd = 3,
+  mean.lwd = 1,
   mean.col = "grey",
   fill = TRUE,
   intervals = NULL,

--- a/tests/testthat/test-openColours.R
+++ b/tests/testthat/test-openColours.R
@@ -122,24 +122,6 @@ test_that("user-supplied colours respect direction and alpha", {
   expect_true(all(substr(cols, 8, 9) == "00"))
 })
 
-test_that("invalid alpha throws an error", {
-  expect_error(openColours("jet", 5, alpha = -0.1), "alpha")
-  expect_error(openColours("jet", 5, alpha = 1.1), "alpha")
-})
-
-test_that("invalid direction throws an error", {
-  expect_error(openColours("jet", 5, direction = 0), "direction")
-  expect_error(openColours("jet", 5, direction = 2), "direction")
-  expect_error(openColours("jet", 5, direction = "reverse"), "direction")
-})
-
-test_that("invalid begin/end throws an error", {
-  expect_error(openColours("jet", 5, begin = -0.1), "begin")
-  expect_error(openColours("jet", 5, end = 1.1), "end")
-  expect_error(openColours("jet", 5, begin = 0.8, end = 0.2), "begin")
-  expect_error(openColours("jet", 5, begin = 0.5, end = 0.5), "begin")
-})
-
 test_that("requesting too many colours from a qualitative palette throws an error", {
   expect_error(openColours("daqi.bands", 5), "Too many")
   expect_error(openColours("gaf.focus", 3), "Too many")


### PR DESCRIPTION
This rounds off the sensible arguments to be available in `openColours()`.

These sit at default values of 0.5. A value up to 1 will saturate/brighten the colours, a value down to 0 will desaturate/darken the colours.

<img width="968" height="735" alt="image" src="https://github.com/user-attachments/assets/3783e324-a0bb-4251-93b1-75e2b34f5a6c" />

