### PR TITLE
feat: add `breaks` to `trajLevel()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -58,7 +58,7 @@
     
     - `breaks` can now take a named list, defined using the new `breakOpts()` function. Most significantly, this allows for the method of binning to change for single-value `breaks` (quantiles, equal range bins, user-defined bin widths, approximate 'pretty' breaks and wind direction binning at time of writing).
     
-    - `polarPlot()`, `polarAnnulus()` and `corPlot()` have gained `breaks`.
+    - `polarPlot()`, `polarAnnulus()`, `corPlot()` and `trajLevel()` have gained `breaks`.
     
     - `labels` is no longer a top-level argument and can be defined by passing a list to `breaks`. `labels` given to `...` will be converted with a warning.
 

--- a/R/trajLevel.R
+++ b/R/trajLevel.R
@@ -865,6 +865,7 @@ trajLevel <- function(
       thePlot +
       ggplot2::geom_hex(
         data = original_data,
+        show.legend = TRUE,
         ggplot2::aes(
           x = .data$xgrid,
           y = .data$ygrid,

--- a/R/trajLevel.R
+++ b/R/trajLevel.R
@@ -98,6 +98,14 @@
 #'   values reveal source regions more effectively while not introducing too
 #'   much noise.
 #'
+#' @param breaks `breaks` bins a continuous axis into discrete bins. It can
+#'   either take a single number (e.g., `breaks = 5`) to split the scale into
+#'   quantiles, a vector of numbers (e.g., `breaks = c(0, 50, 100, 200, 500`) to
+#'   define specific break-points, or a named list. See [breakOpts()] for more
+#'   details. Note that, in `trajLevel()`, each `statistic` provides a different
+#'   default break strategy; to override those that bin the limits by default
+#'   (e.g., `"frequency"`), pass `breaks = NULL` explicitly.
+#'
 #' @export
 #' @return an [openair][openair-package] object
 #' @family trajectory analysis functions
@@ -163,6 +171,7 @@ trajLevel <- function(
   percentile = 90,
   lon.inc = 1.0,
   lat.inc = lon.inc,
+  breaks = NULL,
   min.bin = 1,
   .combine = NULL,
   sigma = 1.5,
@@ -350,6 +359,18 @@ trajLevel <- function(
           .include_default = TRUE
         )
     }
+
+    # default is no cuts in the data
+    if (!missing(breaks)) {
+      break_opts <- resolve_break_opts(breaks, extra.args)
+      out_data <- dplyr::mutate(
+        out_data,
+        {{ pollutant }} := cut_plot_breaks(
+          .data[[pollutant]],
+          opts = break_opts
+        )
+      )
+    }
   }
 
   # plot trajectory frequencies
@@ -379,15 +400,23 @@ trajLevel <- function(
         )
     }
 
+    # default is to use set breaks
+    if (!missing(breaks)) {
+      break_opts <- resolve_break_opts(breaks, extra.args)
+    } else {
+      break_opts <- breakOpts(
+        breaks = c(0, 1, 5, 10, 25, 100),
+        labels = c("0 to 1", "1 to 5", "5 to 10", "10 to 25", "25 to 100"),
+        include.lowest = TRUE
+      ) |>
+        resolve_break_opts(extra.args = extra.args)
+    }
+
+    # cut data
     mydata <-
       dplyr::mutate(
         mydata,
-        cuts = cut(
-          .data[[pollutant]],
-          breaks = c(0, 1, 5, 10, 25, 100),
-          labels = c("0 to 1", "1 to 5", "5 to 10", "10 to 25", "25 to 100"),
-          include.lowest = TRUE
-        )
+        {{ pollutant }} := cut_plot_breaks(.data[[pollutant]], break_opts)
       )
 
     # prep output data
@@ -439,6 +468,18 @@ trajLevel <- function(
           \(x) smooth_trajgrid(x, z = pollutant),
           .include_default = TRUE
         )
+    }
+
+    # default is no cuts in the data
+    if (!missing(breaks)) {
+      break_opts <- resolve_break_opts(breaks, extra.args)
+      mydata <- dplyr::mutate(
+        mydata,
+        {{ pollutant }} := cut_plot_breaks(
+          .data[[pollutant]],
+          opts = break_opts
+        )
+      )
     }
 
     # prep output data
@@ -510,6 +551,18 @@ trajLevel <- function(
         )
     }
 
+    # default is no cuts in the data
+    if (!missing(breaks)) {
+      break_opts <- resolve_break_opts(breaks, extra.args)
+      mydata <- dplyr::mutate(
+        mydata,
+        {{ pollutant }} := cut_plot_breaks(
+          .data[[pollutant]],
+          opts = break_opts
+        )
+      )
+    }
+
     out_data <- dplyr::ungroup(mydata) |>
       dplyr::select(
         -dplyr::any_of(c("lat_rnd", "lon_rnd", "Q", "Q_c", "SQTBA"))
@@ -560,6 +613,9 @@ trajLevel <- function(
     mydata <- base
     mydata[[pollutant]] <- high[[pollutant]] - mydata[[pollutant]]
 
+    ## select only if > min.bin points in grid cell
+    mydata <- dplyr::filter(mydata, .data$count >= min.bin)
+
     if (smooth) {
       mydata <-
         map_type(
@@ -570,27 +626,31 @@ trajLevel <- function(
         )
     }
 
+    # default is to use set breaks
+    if (!missing(breaks)) {
+      break_opts <- resolve_break_opts(breaks, extra.args)
+    } else {
+      break_opts <- breakOpts(
+        breaks = c(-Inf, -10, -5, -1, 1, 5, 10, Inf),
+        labels = c(
+          "<-10",
+          "-10 to -5",
+          "-5 to -1",
+          "-1 to 1",
+          "1 to 5",
+          "5 to 10",
+          ">10"
+        ),
+        include.lowest = TRUE
+      ) |>
+        resolve_break_opts(extra.args = extra.args)
+    }
+
     mydata <-
       dplyr::mutate(
         mydata,
-        cuts = cut(
-          .data[[pollutant]],
-          breaks = c(-Inf, -10, -5, -1, 1, 5, 10, Inf),
-          labels = c(
-            "<-10",
-            "-10 to -5",
-            "-5 to -1",
-            "-1 to 1",
-            "1 to 5",
-            "5 to 10",
-            ">10"
-          ),
-          include.lowest = TRUE
-        )
+        {{ pollutant }} := cut_plot_breaks(.data[[pollutant]], break_opts)
       )
-
-    ## select only if > min.bin points in grid cell
-    mydata <- dplyr::filter(mydata, .data$count >= min.bin)
 
     # prep output data
     out_data <- dplyr::ungroup(mydata) |>
@@ -692,21 +752,22 @@ trajLevel <- function(
   }
 
   # each statistic needs different handling
+  is_discrete <- is.factor(out_data_sf[[pollutant]])
 
   # discrete statistics
-  if (statistic %in% c("frequency", "difference")) {
+  if (is_discrete && statistic != "hexbin") {
     thePlot <-
       thePlot +
       ggplot2::geom_sf(
         data = out_data_sf,
-        ggplot2::aes(fill = .data$cuts),
+        ggplot2::aes(fill = .data[[pollutant]]),
         colour = extra.args$border,
         show.legend = TRUE
       ) +
       ggplot2::scale_fill_manual(
         values = resolve_colour_opts(
           cols,
-          n = dplyr::n_distinct(levels(out_data_sf$cuts))
+          n = dplyr::n_distinct(levels(out_data_sf[[pollutant]]))
         ),
         drop = FALSE
       ) +
@@ -725,7 +786,7 @@ trajLevel <- function(
             if (key.position %in% c("left", "right")) {
               NULL
             } else {
-              dplyr::n_distinct(levels(out_data_sf$cuts))
+              dplyr::n_distinct(levels(out_data_sf[[pollutant]]))
             }
           } else {
             key.columns
@@ -735,7 +796,7 @@ trajLevel <- function(
   }
 
   # continuous statistics
-  if (statistic %in% c("pscf", "cwt", "sqtba")) {
+  if (!is_discrete && statistic != "hexbin") {
     thePlot <-
       thePlot +
       ggplot2::geom_sf(
@@ -747,7 +808,8 @@ trajLevel <- function(
       ggplot2::scale_fill_gradientn(
         colours = resolve_colour_opts(cols, 100),
         oob = scales::oob_squish,
-        na.value = NA
+        na.value = NA,
+        limits = extra.args$limits
       )
   }
 
@@ -794,6 +856,11 @@ trajLevel <- function(
   # hexbin needs separate handling - everything needs to be set as lat/lng as
   # ggplot2 needs to transform everything simultaneously
   if (statistic == "hexbin") {
+    missing_breaks <- missing(breaks)
+
+    # default is no cuts in the data
+    break_opts <- resolve_break_opts(breaks, extra.args)
+
     thePlot <-
       thePlot +
       ggplot2::geom_hex(
@@ -801,6 +868,7 @@ trajLevel <- function(
         ggplot2::aes(
           x = .data$xgrid,
           y = .data$ygrid,
+          fill = cut_plot_breaks(ggplot2::after_stat(.data$count), break_opts),
           alpha = as.integer(ggplot2::after_stat(.data$count) >= min.bin)
         ),
         binwidth = min(c(lat.inc * 1.5, lon.inc * 1.5))
@@ -836,16 +904,57 @@ trajLevel <- function(
       ) +
       ggplot2::scale_x_continuous(breaks = scales::breaks_pretty(grid.nx)) +
       ggplot2::scale_y_continuous(breaks = scales::breaks_pretty(grid.ny)) +
-      ggplot2::scale_alpha_identity() +
-      ggplot2::scale_fill_stepsn(
-        transform = scales::transform_log10(),
-        colors = resolve_colour_opts(cols, 100),
-        n.breaks = 15,
-        limits = c(min.bin, NA)
-      ) +
-      ggplot2::guides(
-        fill = ggplot2::guide_colorsteps(show.limits = TRUE)
-      )
+      ggplot2::scale_alpha_identity()
+
+    if (missing(breaks)) {
+      thePlot <-
+        thePlot +
+        ggplot2::scale_fill_stepsn(
+          transform = scales::transform_log10(),
+          colors = resolve_colour_opts(cols, 100),
+          n.breaks = 15,
+          limits = c(min.bin, NA)
+        ) +
+        ggplot2::guides(
+          fill = ggplot2::guide_colorsteps(show.limits = TRUE)
+        )
+    } else if (is.null(break_opts$breaks)) {
+      thePlot <- thePlot +
+        ggplot2::scale_fill_gradientn(
+          colours = resolve_colour_opts(cols, 100),
+          oob = scales::oob_squish,
+          na.value = NA,
+          limits = extra.args$limits
+        )
+    } else {
+      thePlot <- thePlot +
+        ggplot2::scale_fill_discrete(
+          palette = \(x) resolve_colour_opts(cols, x),
+          drop = FALSE
+        ) +
+        ggplot2::guides(
+          fill = ggplot2::guide_legend(
+            reverse = key.position %in% c("left", "right"),
+            theme = ggplot2::theme(
+              legend.title.position = ifelse(
+                key.position %in% c("left", "right"),
+                "top",
+                key.position
+              ),
+              legend.text.position = key.position
+            ),
+            ncol = if (missing(key.columns)) {
+              if (key.position %in% c("left", "right")) {
+                NULL
+              } else {
+                dplyr::n_distinct(levels(out_data_sf[[pollutant]]))
+              }
+            } else {
+              key.columns
+            }
+          )
+        )
+    }
   }
 
   # make legends full width

--- a/man/trajLevel.Rd
+++ b/man/trajLevel.Rd
@@ -15,6 +15,7 @@ trajLevel(
   percentile = 90,
   lon.inc = 1,
   lat.inc = lon.inc,
+  breaks = NULL,
   min.bin = 1,
   .combine = NULL,
   sigma = 1.5,
@@ -100,6 +101,14 @@ the all trajectories are compared.}
 binning data. If \code{statistic = "hexbin"}, the minimum value out of of
 \code{lon.inc} and \code{lat.inc} is passed to the \code{binwidth} argument of
 \code{\link[ggplot2:geom_hex]{ggplot2::geom_hex()}}.}
+
+\item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
+either take a single number (e.g., \code{breaks = 5}) to split the scale into
+quantiles, a vector of numbers (e.g., \verb{breaks = c(0, 50, 100, 200, 500}) to
+define specific break-points, or a named list. See \code{\link[=breakOpts]{breakOpts()}} for more
+details. Note that, in \code{trajLevel()}, each \code{statistic} provides a different
+default break strategy; to override those that bin the limits by default
+(e.g., \code{"frequency"}), pass \code{breaks = NULL} explicitly.}
 
 \item{min.bin}{The minimum number of unique points in a grid cell. Counts
 below \code{min.bin} are set as missing.}

--- a/tests/testthat/test-trajLevel.R
+++ b/tests/testthat/test-trajLevel.R
@@ -39,15 +39,6 @@ test_that("frequency: xgrid and ygrid are rounded to nearest degree (default lon
   expect_true(all(tl$data$ygrid == round(tl$data$ygrid)))
 })
 
-test_that("frequency: 'cuts' factor with expected levels is present", {
-  expect_true("cuts" %in% names(tl$data))
-  expect_true(is.factor(tl$data$cuts))
-  expect_true(all(
-    levels(tl$data$cuts) %in%
-      c("0 to 1", "1 to 5", "5 to 10", "10 to 25", "25 to 100")
-  ))
-})
-
 # --- statistic = "pscf" ------------------------------------------------------
 
 test_that("statistic = 'pscf' returns values in [0, 1]", {
@@ -85,20 +76,6 @@ test_that("statistic = 'cwt' returns non-negative values", {
   )
   non_na <- tl_cwt$data$nox[!is.na(tl_cwt$data$nox)]
   expect_true(all(non_na >= 0))
-})
-
-# --- statistic = "difference" ------------------------------------------------
-
-test_that("statistic = 'difference' produces a cuts factor column", {
-  tl_diff <- trajLevel(
-    traj,
-    pollutant = "nox",
-    statistic = "difference",
-    map = FALSE,
-    plot = FALSE
-  )
-  expect_true("cuts" %in% names(tl_diff$data))
-  expect_true(is.factor(tl_diff$data$cuts))
 })
 
 # --- lon.inc / lat.inc -------------------------------------------------------


### PR DESCRIPTION
This PR adds `breaks` to `trajLevel()`.

It works the same way as `breaks` does everywhere else, *except* that it will use a different default `breaks` strategy for the different statistics (e.g., hexbin is binned by default).