### PR TITLE
feat: add `trans` to transform continuous colour scales

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,8 @@
     
     - `labels` is no longer a top-level argument and can be defined by passing a list to `breaks`. `labels` given to `...` will be converted with a warning.
 
+- All functions which take `breaks` also now contain the `trans` argument to perform scale transforms on continuous colour scales. This can take `FALSE` (no scale transform), `TRUE` (an appropriate default transform - usually `"log10"`), or a `{scales}` transform object (or string shorthand).
+
 - Refinements to colours in `{openair}`:
 
     - `openColours()` gains `direction`, `alpha`, `begin`, `end`, `lightness` and `saturation` for better control over colour palettes.

--- a/R/calendarPlot.R
+++ b/R/calendarPlot.R
@@ -188,6 +188,8 @@ calendarPlot <-
     windflow = NULL,
     cols = "heat",
     limits = NULL,
+    breaks = NULL,
+    trans = FALSE,
     lim = NULL,
     col.lim = c("grey30", "black"),
     col.na = "white",
@@ -195,7 +197,6 @@ calendarPlot <-
     cex.lim = c(0.6, 0.9),
     cex.date = 0.6,
     digits = 0,
-    breaks = NULL,
     w.shift = 0,
     w.abbr.len = 1,
     remove.empty = TRUE,
@@ -601,7 +602,8 @@ calendarPlot <-
           colours = resolve_colour_opts(cols, 100),
           na.value = col.na,
           oob = scales::oob_squish,
-          limit = limits
+          limit = limits,
+          transform = get_scale_transform(trans)
         ) +
         ggplot2::guides(
           fill = ggplot2::guide_colorbar(

--- a/R/calendarPlot.R
+++ b/R/calendarPlot.R
@@ -70,13 +70,6 @@
 #'   provide the associated `ws` or `wd` and not the maximum/minimum daily `ws`
 #'   or `wd`.
 #'
-#' @param limits Use this option to manually set the colour scale limits. This
-#'   is useful in the case when there is a need for two or more plots and a
-#'   consistent scale is needed on each. Set the limits to cover the maximum
-#'   range of the data for all plots of interest. For example, if one plot had
-#'   data covering 0--60 and another 0--100, then set `limits = c(0, 100)`. Note
-#'   that data will be ignored if outside the limits range.
-#'
 #' @param lim A threshold value to help differentiate values above and below
 #'   `lim`. It is used when `annotate = "value"`. See next few options for
 #'   control over the labels used.

--- a/R/corPlot.R
+++ b/R/corPlot.R
@@ -113,6 +113,7 @@ corPlot <- function(
   triangle = c("both", "upper", "lower"),
   diagonal = TRUE,
   breaks = NULL,
+  trans = FALSE,
   cols = "default",
   r.thresh = 0.8,
   text.col = c("black", "black"),
@@ -501,7 +502,8 @@ corPlot <- function(
       ggplot2::scale_fill_gradientn(
         colours = resolve_colour_opts(cols, n = 100),
         limits = c(-1, 1),
-        oob = scales::oob_squish
+        oob = scales::oob_squish,
+        transform = get_scale_transform(trans)
       ) +
       ggplot2::guides(
         fill = ggplot2::guide_colorbar(

--- a/R/ggplot2-utils.R
+++ b/R/ggplot2-utils.R
@@ -242,6 +242,37 @@ scale_x_compass <- function(
   )
 }
 
+# turn a 'trans' argument into a ggplot2 scale transformer
+get_scale_transform <- function(
+  transform,
+  default = scales::transform_log10()
+) {
+  if (inherits(transform, "transform")) {
+    return(transform)
+  }
+
+  if (rlang::is_function(transform)) {
+    if (inherits(transform, "transform")) {
+      return(transform)
+    }
+  }
+
+  if (rlang::is_logical(transform)) {
+    if (transform) {
+      return(default)
+    } else {
+      return(scales::transform_identity())
+    }
+  }
+
+  if (rlang::is_character(transform)) {
+    return(eval(parse(text = paste0("scales::transform_", transform, "()"))))
+  }
+
+  cli::cli_abort(
+    "{.arg trans} must be logical, a string, or a {.pkg scales} 'transform' object."
+  )
+}
 
 # Layers ------------------------------------------------------------------
 

--- a/R/polarAnnulus.R
+++ b/R/polarAnnulus.R
@@ -142,6 +142,8 @@ polarAnnulus <-
     statistic = "mean",
     percentile = NA,
     limits = NULL,
+    breaks = NULL,
+    trans = FALSE,
     cols = "default",
     col.na = "grey",
     offset = 50,
@@ -152,7 +154,6 @@ polarAnnulus <-
     force.positive = TRUE,
     k = c(20, 10),
     normalise = FALSE,
-    breaks = NULL,
     key.title = paste(statistic, pollutant, sep = " "),
     key.position = "right",
     auto.text = TRUE,
@@ -633,7 +634,8 @@ polarAnnulus <-
               aesthetics = c("colour", "fill"),
               limits = limits,
               breaks = scales::breaks_pretty(6),
-              na.value = col.na
+              na.value = col.na,
+              transform = get_scale_transform(trans)
             ),
             ggplot2::guides(
               fill = ggplot2::guide_colorbar(

--- a/R/polarFreq.R
+++ b/R/polarFreq.R
@@ -62,12 +62,6 @@
 #'
 #' @param grid.line Radial spacing of grid lines.
 #'
-#' @param trans Should a transformation be applied? Sometimes when producing
-#'   plots of this kind they can be dominated by a few high points. The default
-#'   therefore is `TRUE` and a square-root transform is applied. This results in
-#'   a non-linear scale and (usually) a better representation of the
-#'   distribution. If set to `FALSE` a linear scale is used.
-#'
 #' @param ws.upper A user-defined upper wind speed to use. This is useful for
 #'   ensuring a consistent scale between different plots. For example, to always
 #'   ensure that wind speeds are displayed between 1-10, set `ws.int = 10`.
@@ -123,9 +117,13 @@
 #'
 #' # source contribution plot and use of offset option
 #' \dontrun{
-#' polarFreq(mydata,
+#' polarFreq(
+#'   mydata,
 #'   pollutant = "pm25",
-#'   statistic = "weighted.mean", offset = 50, ws.int = 25, trans = FALSE
+#'   statistic = "weighted.mean",
+#'   offset = 50,
+#'   ws.int = 25,
+#'   trans = FALSE
 #' )
 #' }
 polarFreq <- function(
@@ -139,8 +137,8 @@ polarFreq <- function(
   grid.line = 5,
   limits = NULL,
   breaks = NULL,
+  trans = "sqrt",
   cols = "default",
-  trans = TRUE,
   type = "default",
   min.bin = 1,
   ws.upper = NA,
@@ -211,11 +209,6 @@ polarFreq <- function(
       "x" = "No {.field pollutant} chosen",
       "i" = "Please choose a {.field pollutant}, e.g., {.code pollutant = 'nox'}"
     ))
-  }
-
-  # over-ride transform if breaks supplied
-  if (!(any(is.null(break_opts$breaks)) || anyNA(break_opts$breaks))) {
-    trans <- FALSE
   }
 
   # replace weighted.mean with a nicer label
@@ -404,7 +397,10 @@ polarFreq <- function(
       thePlot +
       ggplot2::scale_fill_gradientn(
         colours = resolve_colour_opts(cols, 100),
-        transform = ifelse(trans, "sqrt", "identity"),
+        transform = get_scale_transform(
+          trans,
+          default = scales::transform_sqrt()
+        ),
         oob = scales::oob_squish,
         breaks = scales::pretty_breaks(6),
         limits = limits

--- a/R/polarFreq.R
+++ b/R/polarFreq.R
@@ -53,8 +53,6 @@
 #'   Note that for options other than `"frequency"`, it is necessary to also
 #'   provide the name of a `pollutant`.
 #'
-#' @param limits The limits of the colour bar (e.g., `c(0, 100)`).
-#'
 #' @param ws.int Wind speed interval assumed. In some cases e.g. a low met mast,
 #'   an interval of 0.5 may be more appropriate.
 #'

--- a/R/polarPlot.R
+++ b/R/polarPlot.R
@@ -141,12 +141,6 @@
 #'   determination of the slope. The uncertainties are provided by
 #'   `x_error` and `y_error` --- see below.}
 #'
-#' @param limits The function does its best to choose sensible limits
-#'   automatically. However, there are circumstances when the user will wish to
-#'   set different ones. An example would be a series of plots showing each year
-#'   of data separately. The limits are set in the form `c(lower, upper)`, so
-#'   `limits = c(0, 100)` would force the plot limits to span 0-100.
-#'
 #' @param exclude.missing Setting this option to `TRUE` (the default) removes
 #'   points from the plot that are too far from the original data. The smoothing
 #'   routines will produce predictions at points where no data exist i.e. they

--- a/R/polarPlot.R
+++ b/R/polarPlot.R
@@ -360,6 +360,8 @@ polarPlot <-
     type = "default",
     statistic = "mean",
     limits = NULL,
+    breaks = NULL,
+    trans = FALSE,
     exclude.missing = TRUE,
     uncertainty = FALSE,
     percentile = NA,
@@ -373,7 +375,6 @@ polarPlot <-
     force.positive = TRUE,
     k = 100,
     normalise = FALSE,
-    breaks = NULL,
     key.title = paste(statistic, pollutant, sep = " "),
     key.position = "right",
     auto.text = TRUE,
@@ -964,7 +965,8 @@ polarPlot <-
               aesthetics = c("fill", "colour"),
               oob = scales::oob_squish,
               na.value = col.na,
-              limits = limits
+              limits = limits,
+              trans = get_scale_transform(trans)
             ),
             ggplot2::guides(
               fill = ggplot2::guide_colorbar(

--- a/R/scatterPlot.R
+++ b/R/scatterPlot.R
@@ -129,9 +129,7 @@
 #'   values - e.g., `shape = c(1, 2)` - which will be recycled to the length of
 #'   values needed.
 #'
-#'   - For `method = "hexbin"` a log-scale fill is applied by default;
-#'   pass `trans = NULL` to disable or provide custom `trans` and `inv`
-#'   transform functions. `bins` controls the number of bins.
+#'   - For `method = "hexbin"`, `bins` controls the number of bins.
 #'
 #'   - `date.format` controls the format of date-time x-axes.
 #'
@@ -238,6 +236,7 @@ scatterPlot <- function(
   x.inc = NULL,
   y.inc = NULL,
   limits = NULL,
+  trans = FALSE,
   windflow = NULL,
   ref.x = NULL,
   ref.y = NULL,
@@ -326,6 +325,7 @@ scatterPlot <- function(
       key.title = key.title,
       key.columns = key.columns,
       limits = limits,
+      trans = trans,
       k = k,
       auto.text = auto.text,
       xlab = xlab,
@@ -352,6 +352,7 @@ scatterPlot <- function(
       ref.x = ref.x,
       ref.y = ref.y,
       key.position = key.position,
+      trans = trans,
       auto.text = auto.text,
       xlab = xlab,
       ylab = ylab,
@@ -379,6 +380,7 @@ scatterPlot <- function(
       ref.x = ref.x,
       ref.y = ref.y,
       key.position = key.position,
+      trans = trans,
       k = k,
       dist = dist,
       auto.text = auto.text,
@@ -402,6 +404,7 @@ scatterPlot <- function(
       ref.x = ref.x,
       ref.y = ref.y,
       key.position = key.position,
+      trans = trans,
       auto.text = auto.text,
       xlab = xlab,
       ylab = ylab,
@@ -530,8 +533,8 @@ scatter_scatter <- function(
   key.position,
   key.title,
   key.columns,
-
   limits,
+  trans,
   k,
   auto.text,
   xlab,
@@ -622,6 +625,7 @@ scatter_scatter <- function(
         guide = ggplot2::guide_colorbar(
           position = key.position
         ),
+        transform = get_scale_transform(trans %||% "identity"),
         aesthetics = c("colour", "fill")
       ) +
       ggplot2::labs(
@@ -880,7 +884,7 @@ scatter_hexbin <- function(
   ref.x,
   ref.y,
   key.position,
-
+  trans,
   auto.text,
   xlab,
   ylab,
@@ -894,23 +898,11 @@ scatter_hexbin <- function(
 
   myColors <- resolve_colour_opts(cols, 200)
 
-  ## hexbin fill transform (default: log; trans = NULL → none)
-  hex_transform <- if (
-    "trans" %in% names(extra.args) && is.null(extra.args$trans)
-  ) {
-    "identity"
-  } else if ("trans" %in% names(extra.args) && is.function(extra.args$trans)) {
-    inv_fn <- extra.args$inv %||% function(x) x
-    scales::new_transform("hex_custom", extra.args$trans, inv_fn)
-  } else {
-    "log"
-  }
-
   plt <- ggplot2::ggplot(mydata, ggplot2::aes(x = .data[[x]], y = .data[[y]])) +
     ggplot2::geom_hex(bins = extra.args$bins %||% 30, colour = border) +
     ggplot2::scale_fill_gradientn(
       colors = myColors,
-      transform = hex_transform,
+      transform = get_scale_transform(trans %||% "log10"),
       labels = scales::label_number(accuracy = 1),
       guide = ggplot2::guide_colorbar(
         position = key.position
@@ -1017,7 +1009,7 @@ scatter_level <- function(
   ref.x,
   ref.y,
   key.position,
-
+  trans,
   k,
   dist,
   auto.text,
@@ -1112,7 +1104,8 @@ scatter_level <- function(
       na.value = "transparent",
       guide = ggplot2::guide_colorbar(
         position = key.position
-      )
+      ),
+      transform = get_scale_transform(trans %||% "identity")
     ) +
     ggplot2::labs(
       fill = quickText(z, auto.text)
@@ -1266,7 +1259,7 @@ scatter_density <- function(
   ref.x,
   ref.y,
   key.position,
-
+  trans,
   auto.text,
   xlab,
   ylab,
@@ -1301,7 +1294,8 @@ scatter_density <- function(
       na.value = "transparent",
       guide = ggplot2::guide_colorbar(
         position = key.position
-      )
+      ),
+      transform = get_scale_transform(trans %||% "identity")
     ) +
     ggplot2::labs(
       fill = "intensity"

--- a/R/scatterPlot.R
+++ b/R/scatterPlot.R
@@ -91,12 +91,6 @@
 #' @param x.inc,y.inc The x/y-interval to be used for binning data when `method
 #'   = "level"`.
 #'
-#' @param limits For `method = "level"` the function does its best to choose
-#'   sensible limits automatically. However, there are circumstances when the
-#'   user will wish to set different ones. The limits are set in the form
-#'   `c(lower, upper)`, so `limits = c(0, 100)` would force the plot limits to
-#'   span 0-100.
-#'
 #' @param k Smoothing parameter supplied to `gam` for fitting a smooth surface
 #'   when `method = "level"`.
 #'

--- a/R/shared-docs.R
+++ b/R/shared-docs.R
@@ -83,6 +83,22 @@
 #'   expressed on a scale of `0` to `100`, where `0` is no hole and `100` is a
 #'   hole that takes up the entire plotting area.
 #'
+#' @param trans Should a transformation be applied to the colour scale? If the
+#'   distribution of data is skewed, the default scale may be dominated by a few
+#'   high values, so a log or square-root transform may mean the whole colour
+#'   scale is better presented on the plot. Can be:
+#'
+#'   - `FALSE`, which performs no transform.
+#'
+#'   - `TRUE`, which uses an appropriate transform for the plot type (usually
+#'   `"log10"`).
+#'
+#'   - A `scales` 'transform' object (e.g., [scales::transform_log10()]).
+#'
+#'   - A character string corresponding to a `scales` transform function. Useful
+#'   options include `"sqrt"`, `"log10"`, `"log2"`, `"log1p"`, `"pseudo_log"`
+#'   and `"reverse"`.
+#'
 #' @param key.position Location where the legend is to be placed. Allowed
 #'   arguments include `"top"`, `"right"`, `"bottom"`, `"left"` and `"none"`,
 #'   the last of which removes the legend entirely.

--- a/R/shared-docs.R
+++ b/R/shared-docs.R
@@ -83,6 +83,13 @@
 #'   expressed on a scale of `0` to `100`, where `0` is no hole and `100` is a
 #'   hole that takes up the entire plotting area.
 #'
+#' @param limits The limits of the colour scale, in the form `c(lower, upper)`.
+#'   For example, `limits = c(0, 100)` will set the colour scale to be between
+#'   `0` and `100`. Values greater than `100` will be coloured as if they were
+#'   `100`, and those lower than `0` will be coloured as if they were `0`.
+#'   `limits` can be wider than the range of the data, which can be useful for
+#'   ensuring multiple plots share the same colour scale.
+#'
 #' @param trans Should a transformation be applied to the colour scale? If the
 #'   distribution of data is skewed, the default scale may be dominated by a few
 #'   high values, so a log or square-root transform may mean the whole colour

--- a/R/trajLevel.R
+++ b/R/trajLevel.R
@@ -171,7 +171,9 @@ trajLevel <- function(
   percentile = 90,
   lon.inc = 1.0,
   lat.inc = lon.inc,
+  limits = NULL,
   breaks = NULL,
+  trans = FALSE,
   min.bin = 1,
   .combine = NULL,
   sigma = 1.5,
@@ -809,7 +811,8 @@ trajLevel <- function(
         colours = resolve_colour_opts(cols, 100),
         oob = scales::oob_squish,
         na.value = NA,
-        limits = extra.args$limits
+        limits = limits,
+        transform = get_scale_transform(trans)
       )
   }
 
@@ -908,13 +911,17 @@ trajLevel <- function(
       ggplot2::scale_alpha_identity()
 
     if (missing(breaks)) {
+      if (missing(trans)) {
+        trans <- scales::transform_log10()
+      }
+
       thePlot <-
         thePlot +
         ggplot2::scale_fill_stepsn(
-          transform = scales::transform_log10(),
           colors = resolve_colour_opts(cols, 100),
           n.breaks = 15,
-          limits = c(min.bin, NA)
+          limits = c(min.bin, NA),
+          transform = get_scale_transform(trans)
         ) +
         ggplot2::guides(
           fill = ggplot2::guide_colorsteps(show.limits = TRUE)
@@ -925,7 +932,7 @@ trajLevel <- function(
           colours = resolve_colour_opts(cols, 100),
           oob = scales::oob_squish,
           na.value = NA,
-          limits = extra.args$limits
+          limits = limits
         )
     } else {
       thePlot <- thePlot +

--- a/R/trendLevel.R
+++ b/R/trendLevel.R
@@ -53,9 +53,6 @@
 #'   three values are determined by recursion; if more than three values are
 #'   supplied, only the first three are used.
 #'
-#' @param limits The colour scale range to use when generating the
-#'   [trendLevel()] plot.
-#'
 #' @param min.bin The minimum number of records required in a bin to show a
 #'   value. Bins with fewer than `min.bin` records are set to `NA`. The default
 #'   is 1, i.e., all bins with no records are set to `NA`. Setting `min.bin` to

--- a/R/trendLevel.R
+++ b/R/trendLevel.R
@@ -135,12 +135,13 @@ trendLevel <- function(
   n.levels = c(10, 10, 4),
   windflow = NULL,
   limits = NULL,
+  breaks = NULL,
+  trans = FALSE,
   min.bin = 1,
   cols = "default",
   auto.text = TRUE,
   key.title = paste("use.stat.name", pollutant, sep = " "),
   key.position = "right",
-  breaks = NULL,
   statistic = c(
     "mean",
     "max",
@@ -579,7 +580,8 @@ trendLevel <- function(
         colours = resolve_colour_opts(cols, 100),
         na.value = col.na,
         oob = scales::oob_squish,
-        limit = limits
+        limit = limits,
+        transform = get_scale_transform(trans)
       ) +
       ggplot2::guides(
         fill = ggplot2::guide_colorbar(

--- a/man/calendarPlot.Rd
+++ b/man/calendarPlot.Rd
@@ -17,6 +17,8 @@ calendarPlot(
   windflow = NULL,
   cols = "heat",
   limits = NULL,
+  breaks = NULL,
+  trans = FALSE,
   lim = NULL,
   col.lim = c("grey30", "black"),
   col.na = "white",
@@ -24,7 +26,6 @@ calendarPlot(
   cex.lim = c(0.6, 0.9),
   cex.date = 0.6,
   digits = 0,
-  breaks = NULL,
   w.shift = 0,
   w.abbr.len = 1,
   remove.empty = TRUE,
@@ -106,6 +107,21 @@ range of the data for all plots of interest. For example, if one plot had
 data covering 0--60 and another 0--100, then set \code{limits = c(0, 100)}. Note
 that data will be ignored if outside the limits range.}
 
+\item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
+either take a single number (e.g., \code{breaks = 5}) to split the scale into
+quantiles, a vector of numbers (e.g., \verb{breaks = c(0, 50, 100, 200, 500}) to
+define specific break-points, or a named list. See \code{\link[=breakOpts]{breakOpts()}} for more
+details.}
+
+\item{trans}{Should a transformation be applied to the colour scale? If the
+distribution of data is skewed, the default scale may be dominated by a few
+high values, so a log or square-root transform may mean the whole colour
+scale is better presented on the plot. Options include \code{"identity"} (i.e.,
+a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
+an appropriate default transform for the plot (usually \code{"log10"}). See the
+\code{scales} package for more information.}
+
 \item{lim}{A threshold value to help differentiate values above and below
 \code{lim}. It is used when \code{annotate = "value"}. See next few options for
 control over the labels used.}
@@ -129,12 +145,6 @@ the text above \code{lim}.}
 
 \item{digits}{The number of digits used to display concentration values when
 \code{annotate = "value"}.}
-
-\item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
-either take a single number (e.g., \code{breaks = 5}) to split the scale into
-quantiles, a vector of numbers (e.g., \verb{breaks = c(0, 50, 100, 200, 500}) to
-define specific break-points, or a named list. See \code{\link[=breakOpts]{breakOpts()}} for more
-details.}
 
 \item{w.shift}{Controls the order of the days of the week. By default the
 plot shows Saturday first (\code{w.shift = 0}). To change this so that it starts

--- a/man/calendarPlot.Rd
+++ b/man/calendarPlot.Rd
@@ -116,11 +116,16 @@ details.}
 \item{trans}{Should a transformation be applied to the colour scale? If the
 distribution of data is skewed, the default scale may be dominated by a few
 high values, so a log or square-root transform may mean the whole colour
-scale is better presented on the plot. Options include \code{"identity"} (i.e.,
-a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
-and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
-an appropriate default transform for the plot (usually \code{"log10"}). See the
-\code{scales} package for more information.}
+scale is better presented on the plot. Can be:
+\itemize{
+\item \code{FALSE}, which performs no transform.
+\item \code{TRUE}, which uses an appropriate transform for the plot type (usually
+\code{"log10"}).
+\item A \code{scales} 'transform' object (e.g., \code{\link[scales:transform_log10]{scales::transform_log10()}}).
+\item A character string corresponding to a \code{scales} transform function. Useful
+options include \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}.
+}}
 
 \item{lim}{A threshold value to help differentiate values above and below
 \code{lim}. It is used when \code{annotate = "value"}. See next few options for

--- a/man/calendarPlot.Rd
+++ b/man/calendarPlot.Rd
@@ -100,12 +100,12 @@ of R colours (e.g., \code{c("yellow", "green", "blue", "black")} - see
 colour palette more closely (e.g., \code{palette}, \code{direction}, \code{alpha}, etc.).
 See \code{\link[=openColours]{openColours()}} and \code{\link[=colourOpts]{colourOpts()}} for more details.}
 
-\item{limits}{Use this option to manually set the colour scale limits. This
-is useful in the case when there is a need for two or more plots and a
-consistent scale is needed on each. Set the limits to cover the maximum
-range of the data for all plots of interest. For example, if one plot had
-data covering 0--60 and another 0--100, then set \code{limits = c(0, 100)}. Note
-that data will be ignored if outside the limits range.}
+\item{limits}{The limits of the colour scale, in the form \code{c(lower, upper)}.
+For example, \code{limits = c(0, 100)} will set the colour scale to be between
+\code{0} and \code{100}. Values greater than \code{100} will be coloured as if they were
+\code{100}, and those lower than \code{0} will be coloured as if they were \code{0}.
+\code{limits} can be wider than the range of the data, which can be useful for
+ensuring multiple plots share the same colour scale.}
 
 \item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
 either take a single number (e.g., \code{breaks = 5}) to split the scale into

--- a/man/corPlot.Rd
+++ b/man/corPlot.Rd
@@ -97,11 +97,16 @@ details.}
 \item{trans}{Should a transformation be applied to the colour scale? If the
 distribution of data is skewed, the default scale may be dominated by a few
 high values, so a log or square-root transform may mean the whole colour
-scale is better presented on the plot. Options include \code{"identity"} (i.e.,
-a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
-and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
-an appropriate default transform for the plot (usually \code{"log10"}). See the
-\code{scales} package for more information.}
+scale is better presented on the plot. Can be:
+\itemize{
+\item \code{FALSE}, which performs no transform.
+\item \code{TRUE}, which uses an appropriate transform for the plot type (usually
+\code{"log10"}).
+\item A \code{scales} 'transform' object (e.g., \code{\link[scales:transform_log10]{scales::transform_log10()}}).
+\item A character string corresponding to a \code{scales} transform function. Useful
+options include \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}.
+}}
 
 \item{cols}{Colours to use for plotting. Can be a pre-set palette (e.g.,
 \code{"turbo"}, \code{"viridis"}, \code{"tol"}, \code{"Dark2"}, etc.) or a user-defined vector

--- a/man/corPlot.Rd
+++ b/man/corPlot.Rd
@@ -16,6 +16,7 @@ corPlot(
   triangle = c("both", "upper", "lower"),
   diagonal = TRUE,
   breaks = NULL,
+  trans = FALSE,
   cols = "default",
   r.thresh = 0.8,
   text.col = c("black", "black"),
@@ -92,6 +93,15 @@ either take a single number (e.g., \code{breaks = 5}) to split the scale into
 quantiles, a vector of numbers (e.g., \verb{breaks = c(0, 50, 100, 200, 500}) to
 define specific break-points, or a named list. See \code{\link[=breakOpts]{breakOpts()}} for more
 details.}
+
+\item{trans}{Should a transformation be applied to the colour scale? If the
+distribution of data is skewed, the default scale may be dominated by a few
+high values, so a log or square-root transform may mean the whole colour
+scale is better presented on the plot. Options include \code{"identity"} (i.e.,
+a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
+an appropriate default transform for the plot (usually \code{"log10"}). See the
+\code{scales} package for more information.}
 
 \item{cols}{Colours to use for plotting. Can be a pre-set palette (e.g.,
 \code{"turbo"}, \code{"viridis"}, \code{"tol"}, \code{"Dark2"}, etc.) or a user-defined vector

--- a/man/polarAnnulus.Rd
+++ b/man/polarAnnulus.Rd
@@ -15,6 +15,8 @@ polarAnnulus(
   statistic = "mean",
   percentile = NA,
   limits = NULL,
+  breaks = NULL,
+  trans = FALSE,
   cols = "default",
   col.na = "grey",
   offset = 50,
@@ -25,7 +27,6 @@ polarAnnulus(
   force.positive = TRUE,
   k = c(20, 10),
   normalise = FALSE,
-  breaks = NULL,
   key.title = paste(statistic, pollutant, sep = " "),
   key.position = "right",
   auto.text = TRUE,
@@ -122,6 +123,21 @@ set different ones. An example would be a series of plots showing each year
 of data separately. The limits are set in the form \code{c(lower, upper)}, so
 \code{limits = c(0, 100)} would force the plot limits to span 0-100.}
 
+\item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
+either take a single number (e.g., \code{breaks = 5}) to split the scale into
+quantiles, a vector of numbers (e.g., \verb{breaks = c(0, 50, 100, 200, 500}) to
+define specific break-points, or a named list. See \code{\link[=breakOpts]{breakOpts()}} for more
+details.}
+
+\item{trans}{Should a transformation be applied to the colour scale? If the
+distribution of data is skewed, the default scale may be dominated by a few
+high values, so a log or square-root transform may mean the whole colour
+scale is better presented on the plot. Options include \code{"identity"} (i.e.,
+a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
+an appropriate default transform for the plot (usually \code{"log10"}). See the
+\code{scales} package for more information.}
+
 \item{cols}{Colours to use for plotting. Can be a pre-set palette (e.g.,
 \code{"turbo"}, \code{"viridis"}, \code{"tol"}, \code{"Dark2"}, etc.) or a user-defined vector
 of R colours (e.g., \code{c("yellow", "green", "blue", "black")} - see
@@ -185,12 +201,6 @@ mean value. This is done \emph{after} fitting the smooth surface. This option is
 particularly useful if one is interested in the patterns of concentrations
 for several pollutants on different scales e.g. NOx and CO. Often useful if
 more than one \code{pollutant} is chosen.}
-
-\item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
-either take a single number (e.g., \code{breaks = 5}) to split the scale into
-quantiles, a vector of numbers (e.g., \verb{breaks = c(0, 50, 100, 200, 500}) to
-define specific break-points, or a named list. See \code{\link[=breakOpts]{breakOpts()}} for more
-details.}
 
 \item{key.title}{Used to set the title of the legend. The legend title is
 passed to \code{\link[=quickText]{quickText()}} if \code{auto.text = TRUE}.}

--- a/man/polarAnnulus.Rd
+++ b/man/polarAnnulus.Rd
@@ -132,11 +132,16 @@ details.}
 \item{trans}{Should a transformation be applied to the colour scale? If the
 distribution of data is skewed, the default scale may be dominated by a few
 high values, so a log or square-root transform may mean the whole colour
-scale is better presented on the plot. Options include \code{"identity"} (i.e.,
-a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
-and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
-an appropriate default transform for the plot (usually \code{"log10"}). See the
-\code{scales} package for more information.}
+scale is better presented on the plot. Can be:
+\itemize{
+\item \code{FALSE}, which performs no transform.
+\item \code{TRUE}, which uses an appropriate transform for the plot type (usually
+\code{"log10"}).
+\item A \code{scales} 'transform' object (e.g., \code{\link[scales:transform_log10]{scales::transform_log10()}}).
+\item A character string corresponding to a \code{scales} transform function. Useful
+options include \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}.
+}}
 
 \item{cols}{Colours to use for plotting. Can be a pre-set palette (e.g.,
 \code{"turbo"}, \code{"viridis"}, \code{"tol"}, \code{"Dark2"}, etc.) or a user-defined vector

--- a/man/polarAnnulus.Rd
+++ b/man/polarAnnulus.Rd
@@ -117,11 +117,12 @@ this reason it can also be useful to set \code{min.bin} to ensure there are a
 sufficient number of points available to estimate a percentile. See
 \code{quantile} for more details of how percentiles are calculated.}
 
-\item{limits}{The function does its best to choose sensible limits
-automatically. However, there are circumstances when the user will wish to
-set different ones. An example would be a series of plots showing each year
-of data separately. The limits are set in the form \code{c(lower, upper)}, so
-\code{limits = c(0, 100)} would force the plot limits to span 0-100.}
+\item{limits}{The limits of the colour scale, in the form \code{c(lower, upper)}.
+For example, \code{limits = c(0, 100)} will set the colour scale to be between
+\code{0} and \code{100}. Values greater than \code{100} will be coloured as if they were
+\code{100}, and those lower than \code{0} will be coloured as if they were \code{0}.
+\code{limits} can be wider than the range of the data, which can be useful for
+ensuring multiple plots share the same colour scale.}
 
 \item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
 either take a single number (e.g., \code{breaks = 5}) to split the scale into

--- a/man/polarDiff.Rd
+++ b/man/polarDiff.Rd
@@ -63,11 +63,12 @@ possible pollutant source is active or not).
 Most \code{openair} plotting functions can take two \code{type} arguments. If two are
 given, the first is used for the columns and the second for the rows.}
 
-\item{limits}{The function does its best to choose sensible limits
-automatically. However, there are circumstances when the user will wish to
-set different ones. An example would be a series of plots showing each year
-of data separately. The limits are set in the form \code{c(lower, upper)}, so
-\code{limits = c(0, 100)} would force the plot limits to span 0-100.}
+\item{limits}{The limits of the colour scale, in the form \code{c(lower, upper)}.
+For example, \code{limits = c(0, 100)} will set the colour scale to be between
+\code{0} and \code{100}. Values greater than \code{100} will be coloured as if they were
+\code{100}, and those lower than \code{0} will be coloured as if they were \code{0}.
+\code{limits} can be wider than the range of the data, which can be useful for
+ensuring multiple plots share the same colour scale.}
 
 \item{auto.text}{Either \code{TRUE} (default) or \code{FALSE}. If \code{TRUE} titles and
 axis labels will automatically try and format pollutant names and units

--- a/man/polarDiff.Rd
+++ b/man/polarDiff.Rd
@@ -263,11 +263,16 @@ of the plots.}
     \item{\code{trans}}{Should a transformation be applied to the colour scale? If the
 distribution of data is skewed, the default scale may be dominated by a few
 high values, so a log or square-root transform may mean the whole colour
-scale is better presented on the plot. Options include \code{"identity"} (i.e.,
-a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
-and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
-an appropriate default transform for the plot (usually \code{"log10"}). See the
-\code{scales} package for more information.}
+scale is better presented on the plot. Can be:
+\itemize{
+\item \code{FALSE}, which performs no transform.
+\item \code{TRUE}, which uses an appropriate transform for the plot type (usually
+\code{"log10"}).
+\item A \code{scales} 'transform' object (e.g., \code{\link[scales:transform_log10]{scales::transform_log10()}}).
+\item A character string corresponding to a \code{scales} transform function. Useful
+options include \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}.
+}}
     \item{\code{key.position}}{Location where the legend is to be placed. Allowed
 arguments include \code{"top"}, \code{"right"}, \code{"bottom"}, \code{"left"} and \code{"none"},
 the last of which removes the legend entirely.}

--- a/man/polarDiff.Rd
+++ b/man/polarDiff.Rd
@@ -260,6 +260,14 @@ chosen, sometimes the placement of the scale may interfere with an
 interesting feature. \code{angle.scale} can take any value between \code{0} and \code{360}
 to place the scale at a different angle, or \code{FALSE} to move it to the side
 of the plots.}
+    \item{\code{trans}}{Should a transformation be applied to the colour scale? If the
+distribution of data is skewed, the default scale may be dominated by a few
+high values, so a log or square-root transform may mean the whole colour
+scale is better presented on the plot. Options include \code{"identity"} (i.e.,
+a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
+an appropriate default transform for the plot (usually \code{"log10"}). See the
+\code{scales} package for more information.}
     \item{\code{key.position}}{Location where the legend is to be placed. Allowed
 arguments include \code{"top"}, \code{"right"}, \code{"bottom"}, \code{"left"} and \code{"none"},
 the last of which removes the legend entirely.}

--- a/man/polarFreq.Rd
+++ b/man/polarFreq.Rd
@@ -15,8 +15,8 @@ polarFreq(
   grid.line = 5,
   limits = NULL,
   breaks = NULL,
+  trans = "sqrt",
   cols = "default",
-  trans = TRUE,
   type = "default",
   min.bin = 1,
   ws.upper = NA,
@@ -76,18 +76,21 @@ quantiles, a vector of numbers (e.g., \verb{breaks = c(0, 50, 100, 200, 500}) to
 define specific break-points, or a named list. See \code{\link[=breakOpts]{breakOpts()}} for more
 details.}
 
+\item{trans}{Should a transformation be applied to the colour scale? If the
+distribution of data is skewed, the default scale may be dominated by a few
+high values, so a log or square-root transform may mean the whole colour
+scale is better presented on the plot. Options include \code{"identity"} (i.e.,
+a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
+an appropriate default transform for the plot (usually \code{"log10"}). See the
+\code{scales} package for more information.}
+
 \item{cols}{Colours to use for plotting. Can be a pre-set palette (e.g.,
 \code{"turbo"}, \code{"viridis"}, \code{"tol"}, \code{"Dark2"}, etc.) or a user-defined vector
 of R colours (e.g., \code{c("yellow", "green", "blue", "black")} - see
 \code{\link[=colours]{colours()}} for a full list) or hex-codes (e.g., \code{c("#30123B", "#9CF649", "#7A0403")}). Alternatively, can be a list of arguments to control the
 colour palette more closely (e.g., \code{palette}, \code{direction}, \code{alpha}, etc.).
 See \code{\link[=openColours]{openColours()}} and \code{\link[=colourOpts]{colourOpts()}} for more details.}
-
-\item{trans}{Should a transformation be applied? Sometimes when producing
-plots of this kind they can be dominated by a few high points. The default
-therefore is \code{TRUE} and a square-root transform is applied. This results in
-a non-linear scale and (usually) a better representation of the
-distribution. If set to \code{FALSE} a linear scale is used.}
 
 \item{type}{Character string(s) defining how data should be split/conditioned
 before plotting. \code{"default"} produces a single panel using the entire
@@ -264,9 +267,13 @@ polarFreq(mydata, breaks = c(0, 10, 50, 100, 250, 500, 700))
 
 # source contribution plot and use of offset option
 \dontrun{
-polarFreq(mydata,
+polarFreq(
+  mydata,
   pollutant = "pm25",
-  statistic = "weighted.mean", offset = 50, ws.int = 25, trans = FALSE
+  statistic = "weighted.mean",
+  offset = 50,
+  ws.int = 25,
+  trans = FALSE
 )
 }
 }

--- a/man/polarFreq.Rd
+++ b/man/polarFreq.Rd
@@ -68,7 +68,12 @@ an interval of 0.5 may be more appropriate.}
 
 \item{grid.line}{Radial spacing of grid lines.}
 
-\item{limits}{The limits of the colour bar (e.g., \code{c(0, 100)}).}
+\item{limits}{The limits of the colour scale, in the form \code{c(lower, upper)}.
+For example, \code{limits = c(0, 100)} will set the colour scale to be between
+\code{0} and \code{100}. Values greater than \code{100} will be coloured as if they were
+\code{100}, and those lower than \code{0} will be coloured as if they were \code{0}.
+\code{limits} can be wider than the range of the data, which can be useful for
+ensuring multiple plots share the same colour scale.}
 
 \item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
 either take a single number (e.g., \code{breaks = 5}) to split the scale into

--- a/man/polarFreq.Rd
+++ b/man/polarFreq.Rd
@@ -79,11 +79,16 @@ details.}
 \item{trans}{Should a transformation be applied to the colour scale? If the
 distribution of data is skewed, the default scale may be dominated by a few
 high values, so a log or square-root transform may mean the whole colour
-scale is better presented on the plot. Options include \code{"identity"} (i.e.,
-a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
-and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
-an appropriate default transform for the plot (usually \code{"log10"}). See the
-\code{scales} package for more information.}
+scale is better presented on the plot. Can be:
+\itemize{
+\item \code{FALSE}, which performs no transform.
+\item \code{TRUE}, which uses an appropriate transform for the plot type (usually
+\code{"log10"}).
+\item A \code{scales} 'transform' object (e.g., \code{\link[scales:transform_log10]{scales::transform_log10()}}).
+\item A character string corresponding to a \code{scales} transform function. Useful
+options include \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}.
+}}
 
 \item{cols}{Colours to use for plotting. Can be a pre-set palette (e.g.,
 \code{"turbo"}, \code{"viridis"}, \code{"tol"}, \code{"Dark2"}, etc.) or a user-defined vector

--- a/man/polarPlot.Rd
+++ b/man/polarPlot.Rd
@@ -164,11 +164,16 @@ details.}
 \item{trans}{Should a transformation be applied to the colour scale? If the
 distribution of data is skewed, the default scale may be dominated by a few
 high values, so a log or square-root transform may mean the whole colour
-scale is better presented on the plot. Options include \code{"identity"} (i.e.,
-a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
-and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
-an appropriate default transform for the plot (usually \code{"log10"}). See the
-\code{scales} package for more information.}
+scale is better presented on the plot. Can be:
+\itemize{
+\item \code{FALSE}, which performs no transform.
+\item \code{TRUE}, which uses an appropriate transform for the plot type (usually
+\code{"log10"}).
+\item A \code{scales} 'transform' object (e.g., \code{\link[scales:transform_log10]{scales::transform_log10()}}).
+\item A character string corresponding to a \code{scales} transform function. Useful
+options include \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}.
+}}
 
 \item{exclude.missing}{Setting this option to \code{TRUE} (the default) removes
 points from the plot that are too far from the original data. The smoothing

--- a/man/polarPlot.Rd
+++ b/man/polarPlot.Rd
@@ -149,11 +149,12 @@ method the uncertainties in \code{x} and \code{y} are used in the
 determination of the slope. The uncertainties are provided by
 \code{x_error} and \code{y_error} --- see below.}}
 
-\item{limits}{The function does its best to choose sensible limits
-automatically. However, there are circumstances when the user will wish to
-set different ones. An example would be a series of plots showing each year
-of data separately. The limits are set in the form \code{c(lower, upper)}, so
-\code{limits = c(0, 100)} would force the plot limits to span 0-100.}
+\item{limits}{The limits of the colour scale, in the form \code{c(lower, upper)}.
+For example, \code{limits = c(0, 100)} will set the colour scale to be between
+\code{0} and \code{100}. Values greater than \code{100} will be coloured as if they were
+\code{100}, and those lower than \code{0} will be coloured as if they were \code{0}.
+\code{limits} can be wider than the range of the data, which can be useful for
+ensuring multiple plots share the same colour scale.}
 
 \item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
 either take a single number (e.g., \code{breaks = 5}) to split the scale into

--- a/man/polarPlot.Rd
+++ b/man/polarPlot.Rd
@@ -12,6 +12,8 @@ polarPlot(
   type = "default",
   statistic = "mean",
   limits = NULL,
+  breaks = NULL,
+  trans = FALSE,
   exclude.missing = TRUE,
   uncertainty = FALSE,
   percentile = NA,
@@ -25,7 +27,6 @@ polarPlot(
   force.positive = TRUE,
   k = 100,
   normalise = FALSE,
-  breaks = NULL,
   key.title = paste(statistic, pollutant, sep = " "),
   key.position = "right",
   auto.text = TRUE,
@@ -154,6 +155,21 @@ set different ones. An example would be a series of plots showing each year
 of data separately. The limits are set in the form \code{c(lower, upper)}, so
 \code{limits = c(0, 100)} would force the plot limits to span 0-100.}
 
+\item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
+either take a single number (e.g., \code{breaks = 5}) to split the scale into
+quantiles, a vector of numbers (e.g., \verb{breaks = c(0, 50, 100, 200, 500}) to
+define specific break-points, or a named list. See \code{\link[=breakOpts]{breakOpts()}} for more
+details.}
+
+\item{trans}{Should a transformation be applied to the colour scale? If the
+distribution of data is skewed, the default scale may be dominated by a few
+high values, so a log or square-root transform may mean the whole colour
+scale is better presented on the plot. Options include \code{"identity"} (i.e.,
+a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
+an appropriate default transform for the plot (usually \code{"log10"}). See the
+\code{scales} package for more information.}
+
 \item{exclude.missing}{Setting this option to \code{TRUE} (the default) removes
 points from the plot that are too far from the original data. The smoothing
 routines will produce predictions at points where no data exist i.e. they
@@ -263,12 +279,6 @@ mean value. This is done \emph{after} fitting the smooth surface. This option is
 particularly useful if one is interested in the patterns of concentrations
 for several pollutants on different scales e.g. NOx and CO. Often useful if
 more than one \code{pollutant} is chosen.}
-
-\item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
-either take a single number (e.g., \code{breaks = 5}) to split the scale into
-quantiles, a vector of numbers (e.g., \verb{breaks = c(0, 50, 100, 200, 500}) to
-define specific break-points, or a named list. See \code{\link[=breakOpts]{breakOpts()}} for more
-details.}
 
 \item{key.title}{Used to set the title of the legend. The legend title is
 passed to \code{\link[=quickText]{quickText()}} if \code{auto.text = TRUE}.}

--- a/man/scatterPlot.Rd
+++ b/man/scatterPlot.Rd
@@ -31,6 +31,7 @@ scatterPlot(
   x.inc = NULL,
   y.inc = NULL,
   limits = NULL,
+  trans = FALSE,
   windflow = NULL,
   ref.x = NULL,
   ref.y = NULL,
@@ -199,6 +200,20 @@ user will wish to set different ones. The limits are set in the form
 \code{c(lower, upper)}, so \code{limits = c(0, 100)} would force the plot limits to
 span 0-100.}
 
+\item{trans}{Should a transformation be applied to the colour scale? If the
+distribution of data is skewed, the default scale may be dominated by a few
+high values, so a log or square-root transform may mean the whole colour
+scale is better presented on the plot. Can be:
+\itemize{
+\item \code{FALSE}, which performs no transform.
+\item \code{TRUE}, which uses an appropriate transform for the plot type (usually
+\code{"log10"}).
+\item A \code{scales} 'transform' object (e.g., \code{\link[scales:transform_log10]{scales::transform_log10()}}).
+\item A character string corresponding to a \code{scales} transform function. Useful
+options include \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}.
+}}
+
 \item{windflow}{If \code{TRUE}, the vector-averaged wind speed and direction will
 be plotted using arrows. Alternatively, can be a list of arguments to
 control the appearance of the arrows (colour, linewidth, alpha value,
@@ -253,9 +268,7 @@ coordinate plots).
 apply to all plots. These can take a single value, or a vector of multiple
 values - e.g., \code{shape = c(1, 2)} - which will be recycled to the length of
 values needed.
-\item For \code{method = "hexbin"} a log-scale fill is applied by default;
-pass \code{trans = NULL} to disable or provide custom \code{trans} and \code{inv}
-transform functions. \code{bins} controls the number of bins.
+\item For \code{method = "hexbin"}, \code{bins} controls the number of bins.
 \item \code{date.format} controls the format of date-time x-axes.
 }}
 }

--- a/man/scatterPlot.Rd
+++ b/man/scatterPlot.Rd
@@ -194,11 +194,12 @@ can be useful for checking linearity once logged.}
 
 \item{x.inc, y.inc}{The x/y-interval to be used for binning data when \code{method = "level"}.}
 
-\item{limits}{For \code{method = "level"} the function does its best to choose
-sensible limits automatically. However, there are circumstances when the
-user will wish to set different ones. The limits are set in the form
-\code{c(lower, upper)}, so \code{limits = c(0, 100)} would force the plot limits to
-span 0-100.}
+\item{limits}{The limits of the colour scale, in the form \code{c(lower, upper)}.
+For example, \code{limits = c(0, 100)} will set the colour scale to be between
+\code{0} and \code{100}. Values greater than \code{100} will be coloured as if they were
+\code{100}, and those lower than \code{0} will be coloured as if they were \code{0}.
+\code{limits} can be wider than the range of the data, which can be useful for
+ensuring multiple plots share the same colour scale.}
 
 \item{trans}{Should a transformation be applied to the colour scale? If the
 distribution of data is skewed, the default scale may be dominated by a few

--- a/man/shared_openair_params.Rd
+++ b/man/shared_openair_params.Rd
@@ -82,6 +82,15 @@ etc.). See \code{\link[=windflowOpts]{windflowOpts()}} for details.}
 expressed on a scale of \code{0} to \code{100}, where \code{0} is no hole and \code{100} is a
 hole that takes up the entire plotting area.}
 
+\item{trans}{Should a transformation be applied to the colour scale? If the
+distribution of data is skewed, the default scale may be dominated by a few
+high values, so a log or square-root transform may mean the whole colour
+scale is better presented on the plot. Options include \code{"identity"} (i.e.,
+a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
+an appropriate default transform for the plot (usually \code{"log10"}). See the
+\code{scales} package for more information.}
+
 \item{key.position}{Location where the legend is to be placed. Allowed
 arguments include \code{"top"}, \code{"right"}, \code{"bottom"}, \code{"left"} and \code{"none"},
 the last of which removes the legend entirely.}

--- a/man/shared_openair_params.Rd
+++ b/man/shared_openair_params.Rd
@@ -82,6 +82,13 @@ etc.). See \code{\link[=windflowOpts]{windflowOpts()}} for details.}
 expressed on a scale of \code{0} to \code{100}, where \code{0} is no hole and \code{100} is a
 hole that takes up the entire plotting area.}
 
+\item{limits}{The limits of the colour scale, in the form \code{c(lower, upper)}.
+For example, \code{limits = c(0, 100)} will set the colour scale to be between
+\code{0} and \code{100}. Values greater than \code{100} will be coloured as if they were
+\code{100}, and those lower than \code{0} will be coloured as if they were \code{0}.
+\code{limits} can be wider than the range of the data, which can be useful for
+ensuring multiple plots share the same colour scale.}
+
 \item{trans}{Should a transformation be applied to the colour scale? If the
 distribution of data is skewed, the default scale may be dominated by a few
 high values, so a log or square-root transform may mean the whole colour

--- a/man/shared_openair_params.Rd
+++ b/man/shared_openair_params.Rd
@@ -85,11 +85,16 @@ hole that takes up the entire plotting area.}
 \item{trans}{Should a transformation be applied to the colour scale? If the
 distribution of data is skewed, the default scale may be dominated by a few
 high values, so a log or square-root transform may mean the whole colour
-scale is better presented on the plot. Options include \code{"identity"} (i.e.,
-a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
-and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
-an appropriate default transform for the plot (usually \code{"log10"}). See the
-\code{scales} package for more information.}
+scale is better presented on the plot. Can be:
+\itemize{
+\item \code{FALSE}, which performs no transform.
+\item \code{TRUE}, which uses an appropriate transform for the plot type (usually
+\code{"log10"}).
+\item A \code{scales} 'transform' object (e.g., \code{\link[scales:transform_log10]{scales::transform_log10()}}).
+\item A character string corresponding to a \code{scales} transform function. Useful
+options include \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}.
+}}
 
 \item{key.position}{Location where the legend is to be placed. Allowed
 arguments include \code{"top"}, \code{"right"}, \code{"bottom"}, \code{"left"} and \code{"none"},

--- a/man/trajLevel.Rd
+++ b/man/trajLevel.Rd
@@ -104,6 +104,13 @@ binning data. If \code{statistic = "hexbin"}, the minimum value out of of
 \code{lon.inc} and \code{lat.inc} is passed to the \code{binwidth} argument of
 \code{\link[ggplot2:geom_hex]{ggplot2::geom_hex()}}.}
 
+\item{limits}{The limits of the colour scale, in the form \code{c(lower, upper)}.
+For example, \code{limits = c(0, 100)} will set the colour scale to be between
+\code{0} and \code{100}. Values greater than \code{100} will be coloured as if they were
+\code{100}, and those lower than \code{0} will be coloured as if they were \code{0}.
+\code{limits} can be wider than the range of the data, which can be useful for
+ensuring multiple plots share the same colour scale.}
+
 \item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
 either take a single number (e.g., \code{breaks = 5}) to split the scale into
 quantiles, a vector of numbers (e.g., \verb{breaks = c(0, 50, 100, 200, 500}) to

--- a/man/trajLevel.Rd
+++ b/man/trajLevel.Rd
@@ -15,7 +15,9 @@ trajLevel(
   percentile = 90,
   lon.inc = 1,
   lat.inc = lon.inc,
+  limits = NULL,
   breaks = NULL,
+  trans = FALSE,
   min.bin = 1,
   .combine = NULL,
   sigma = 1.5,
@@ -109,6 +111,15 @@ define specific break-points, or a named list. See \code{\link[=breakOpts]{break
 details. Note that, in \code{trajLevel()}, each \code{statistic} provides a different
 default break strategy; to override those that bin the limits by default
 (e.g., \code{"frequency"}), pass \code{breaks = NULL} explicitly.}
+
+\item{trans}{Should a transformation be applied to the colour scale? If the
+distribution of data is skewed, the default scale may be dominated by a few
+high values, so a log or square-root transform may mean the whole colour
+scale is better presented on the plot. Options include \code{"identity"} (i.e.,
+a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
+an appropriate default transform for the plot (usually \code{"log10"}). See the
+\code{scales} package for more information.}
 
 \item{min.bin}{The minimum number of unique points in a grid cell. Counts
 below \code{min.bin} are set as missing.}

--- a/man/trajLevel.Rd
+++ b/man/trajLevel.Rd
@@ -115,11 +115,16 @@ default break strategy; to override those that bin the limits by default
 \item{trans}{Should a transformation be applied to the colour scale? If the
 distribution of data is skewed, the default scale may be dominated by a few
 high values, so a log or square-root transform may mean the whole colour
-scale is better presented on the plot. Options include \code{"identity"} (i.e.,
-a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
-and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
-an appropriate default transform for the plot (usually \code{"log10"}). See the
-\code{scales} package for more information.}
+scale is better presented on the plot. Can be:
+\itemize{
+\item \code{FALSE}, which performs no transform.
+\item \code{TRUE}, which uses an appropriate transform for the plot type (usually
+\code{"log10"}).
+\item A \code{scales} 'transform' object (e.g., \code{\link[scales:transform_log10]{scales::transform_log10()}}).
+\item A character string corresponding to a \code{scales} transform function. Useful
+options include \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}.
+}}
 
 \item{min.bin}{The minimum number of unique points in a grid cell. Counts
 below \code{min.bin} are set as missing.}

--- a/man/trendLevel.Rd
+++ b/man/trendLevel.Rd
@@ -62,8 +62,12 @@ be plotted using arrows. Alternatively, can be a list of arguments to
 control the appearance of the arrows (colour, linewidth, alpha value,
 etc.). See \code{\link[=windflowOpts]{windflowOpts()}} for details.}
 
-\item{limits}{The colour scale range to use when generating the
-\code{\link[=trendLevel]{trendLevel()}} plot.}
+\item{limits}{The limits of the colour scale, in the form \code{c(lower, upper)}.
+For example, \code{limits = c(0, 100)} will set the colour scale to be between
+\code{0} and \code{100}. Values greater than \code{100} will be coloured as if they were
+\code{100}, and those lower than \code{0} will be coloured as if they were \code{0}.
+\code{limits} can be wider than the range of the data, which can be useful for
+ensuring multiple plots share the same colour scale.}
 
 \item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
 either take a single number (e.g., \code{breaks = 5}) to split the scale into

--- a/man/trendLevel.Rd
+++ b/man/trendLevel.Rd
@@ -74,11 +74,16 @@ details.}
 \item{trans}{Should a transformation be applied to the colour scale? If the
 distribution of data is skewed, the default scale may be dominated by a few
 high values, so a log or square-root transform may mean the whole colour
-scale is better presented on the plot. Options include \code{"identity"} (i.e.,
-a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
-and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
-an appropriate default transform for the plot (usually \code{"log10"}). See the
-\code{scales} package for more information.}
+scale is better presented on the plot. Can be:
+\itemize{
+\item \code{FALSE}, which performs no transform.
+\item \code{TRUE}, which uses an appropriate transform for the plot type (usually
+\code{"log10"}).
+\item A \code{scales} 'transform' object (e.g., \code{\link[scales:transform_log10]{scales::transform_log10()}}).
+\item A character string corresponding to a \code{scales} transform function. Useful
+options include \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}.
+}}
 
 \item{min.bin}{The minimum number of records required in a bin to show a
 value. Bins with fewer than \code{min.bin} records are set to \code{NA}. The default

--- a/man/trendLevel.Rd
+++ b/man/trendLevel.Rd
@@ -14,12 +14,13 @@ trendLevel(
   n.levels = c(10, 10, 4),
   windflow = NULL,
   limits = NULL,
+  breaks = NULL,
+  trans = FALSE,
   min.bin = 1,
   cols = "default",
   auto.text = TRUE,
   key.title = paste("use.stat.name", pollutant, sep = " "),
   key.position = "right",
-  breaks = NULL,
   statistic = c("mean", "max", "min", "median", "frequency", "sum", "sd", "percentile"),
   percentile = 95,
   stat.args = NULL,
@@ -64,6 +65,21 @@ etc.). See \code{\link[=windflowOpts]{windflowOpts()}} for details.}
 \item{limits}{The colour scale range to use when generating the
 \code{\link[=trendLevel]{trendLevel()}} plot.}
 
+\item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
+either take a single number (e.g., \code{breaks = 5}) to split the scale into
+quantiles, a vector of numbers (e.g., \verb{breaks = c(0, 50, 100, 200, 500}) to
+define specific break-points, or a named list. See \code{\link[=breakOpts]{breakOpts()}} for more
+details.}
+
+\item{trans}{Should a transformation be applied to the colour scale? If the
+distribution of data is skewed, the default scale may be dominated by a few
+high values, so a log or square-root transform may mean the whole colour
+scale is better presented on the plot. Options include \code{"identity"} (i.e.,
+a linear scale), \code{"sqrt"}, \code{"log10"}, \code{"log2"}, \code{"log1p"}, \code{"pseudo_log"}
+and \code{"reverse"}. \code{FALSE} is equivalent to \code{"identity"} and \code{TRUE} will use
+an appropriate default transform for the plot (usually \code{"log10"}). See the
+\code{scales} package for more information.}
+
 \item{min.bin}{The minimum number of records required in a bin to show a
 value. Bins with fewer than \code{min.bin} records are set to \code{NA}. The default
 is 1, i.e., all bins with no records are set to \code{NA}. Setting \code{min.bin} to
@@ -87,12 +103,6 @@ passed to \code{\link[=quickText]{quickText()}} if \code{auto.text = TRUE}.}
 \item{key.position}{Location where the legend is to be placed. Allowed
 arguments include \code{"top"}, \code{"right"}, \code{"bottom"}, \code{"left"} and \code{"none"},
 the last of which removes the legend entirely.}
-
-\item{breaks}{\code{breaks} bins a continuous axis into discrete bins. It can
-either take a single number (e.g., \code{breaks = 5}) to split the scale into
-quantiles, a vector of numbers (e.g., \verb{breaks = c(0, 50, 100, 200, 500}) to
-define specific break-points, or a named list. See \code{\link[=breakOpts]{breakOpts()}} for more
-details.}
 
 \item{statistic}{The statistic to apply when aggregating the data; default is
 the mean. Can be one of \code{"mean"}, \code{"max"}, \code{"min"}, \code{"median"},


### PR DESCRIPTION
Adds the `trans` arg, which can take `scales::transform_*` functions, text short-hands, or T/F.

Changes default arg of `polarFreq(trans=)` to `"sqrt"`, but `TRUE` still works the same.