### PR TITLE
feat: add extra filtering options to `importMeta()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # openair (development version)
 
+## New Features
+
+- `importMeta()` can now filter by site code, site name, site type, pollutants measured, and the distance from a given coordinate.
+
 ## Bug Fixes
 
 - `trajLevel(statistic = "pscf", smooth = TRUE)` no longer raises an error.

--- a/R/importMeta.R
+++ b/R/importMeta.R
@@ -5,8 +5,10 @@
 #' as the code used in functions like [importUKAQ()], [importImperial()] and
 #' [importEurope()]. Additional information may optionally be returned.
 #'
-#' This function imports site meta data from several networks in the UK and
-#' Europe:
+#' @section Available Networks:
+#'
+#'   This function imports site meta data from several networks in the UK and
+#'   Europe:
 #'
 #' - `"aurn"`,  The [UK Automatic Urban and Rural Network](https://uk-air.defra.gov.uk/).
 #'
@@ -18,37 +20,85 @@
 #'
 #' - `"ni"`,  The [Northern Ireland Air Quality Network](https://www.airqualityni.co.uk/).
 #'
-#' - `"local"`,  [Locally managed](https://uk-air.defra.gov.uk/networks/network-info?view=nondefraaqmon) air quality networks in England.
+#' - `"local"`,  [Locally managed](https://uk-air.defra.gov.uk/networks/network-info?view=nondefraaqmon)
+#'   air quality networks in England.
+#'
 #' - `"imperial"`,  Imperial College London (formerly King's College London) networks.
+#'
 #' - `"europe"`,  Hourly European data (Air Quality e-Reporting) based on a
-#' simplified version of the `{saqgetr}` package.
+#'   simplified version of the `{saqgetr}` package. Note that this data is only
+#'   available until February 2024; see [importEurope()] for more information.
 #'
-#' By default, the function will return the site latitude, longitude and site
-#' type. If the option `all = TRUE` is used, much more detailed information is
-#' returned. The following metadata columns are available in the complete dataset:
+#' @section Order of Operations:
 #'
-#' - **source**: The network with which the site is associated. Note that some monitoring sites are part of multiple networks (e.g., the AURN & SAQN) so the same site may feature twice under different sources.
+#'   This function contains various arguments which allow the user to filter the
+#'   metadata before it is returned. These arguments are applied in the
+#'   following order:
 #'
-#' - **code**: The site code, used to import data from specific sites of interest.
+#'   - `source`
+#'
+#'   - `year`
+#'
+#'   - `pollutant` (where possible)
+#'
+#'   - `code`
+#'
+#'   - `site`
+#'
+#'   - `site_type`
+#'
+#'   - `max_dist`
+#'
+#'   - `max_n`
+#'
+#'   Note that `max_n` is not *always* the number of rows returned by the
+#'   function; it is the maximum number of possible sites to be returned. If
+#'   `all = TRUE`, multiple rows will be present per site. Further, if previous
+#'   filtering steps mean that fewer than `max_n` sites are remaining in the
+#'   data, `max_n` will have no effect.
+#'
+#'   If the combination of arguments provided results in the removal of all
+#'   sites, this function will return an empty dataframe with a warning.
+#'
+#' @section Data Dictionary:
+#'
+#'   By default, the function will return the site latitude, longitude and site
+#'   type. If the option `all = TRUE` is used, much more detailed information is
+#'   returned. The following metadata columns are available in the complete
+#'   dataset:
+#'
+#' - **source**: The network with which the site is associated. Note that
+#'   some monitoring sites are part of multiple networks (e.g., the AURN & SAQN)
+#'   so the same site may feature twice under different sources.
+#'
+#' - **code**: The site code, used to import data from specific sites of
+#'   interest.
 #'
 #' - **site**: The site name, which is more human-readable than the site code.
 #'
-#' - **site_type**: A description of the site environment. Read more at <https://uk-air.defra.gov.uk/networks/site-types>.
+#' - **site_type**: A description of the site environment.
 #'
-#' - **latitude** and **longitude**: The coordinates of the monitoring station, using the World Geodetic System (<https://epsg.io/4326>).
+#' - **latitude** and **longitude**: The coordinates of the monitoring
+#'   station, using the World Geodetic System (<https://epsg.io/4326>).
 #'
-#' - **start_date** and **end_date**: The opening and closing dates of the monitoring station. If `by_pollutant = TRUE`, these dates are instead the first and last dates at which specific pollutants were measured. A missing value, `NA`, indicates that monitoring is ongoing.
+#' - **start_date** and **end_date**: The opening and closing dates of the
+#'   monitoring station. If `by_pollutant = TRUE`, these dates are instead the
+#'   first and last dates at which specific pollutants were measured. A missing
+#'   value, `NA`, indicates that monitoring is ongoing.
 #'
-#' - **ratified_to**: The date to which data has been ratified (i.e., 'quality checked'). Data after this date is subject to change.
+#' - **ratified_to**: The date to which data has been ratified
+#'   (i.e., 'quality checked'). Data after this date is subject to change.
 #'
-#' - **zone** and **agglomeration**: The UK is divided into agglomeration zones (large urban areas) and non-agglomeration zones for air quality assessment, which are given in these columns.
+#' - **zone** and **agglomeration**: The UK is divided into agglomeration
+#'   zones (large urban areas) and non-agglomeration zones for air quality
+#'   assessment, which are given in these columns.
 #'
-#' - **local_authority**: The local authority in which the monitoring station is found.
+#' - **local_authority**: The local authority in which the monitoring station
+#'   is found.
 #'
-#' - **provider** and **code**: The specific provider of the locally managed dataset (e.g., `"londonair"`).
+#' - **provider** and **code**: The specific provider of the locally
+#'   managed dataset (e.g., `"londonair"`).
 #'
-#' Thanks go to Trevor Davies (Ricardo), Dr Stuart Grange (EMPA) and Dr Ben
-#' Barratt (KCL) and  for making these data available.
 #' @param source One or more air quality networks for which data is available
 #'   through openair. Available networks include:
 #'
@@ -63,45 +113,128 @@
 #'
 #'   There are two additional options provided for convenience:
 #'
-#'   - `"ukaq"` will return metadata for all networks for which data is imported by [importUKAQ()] (i.e., AURN, AQE, SAQN, WAQN, NI, and the local networks).
-#'   - `"all"` will import all available metadata (i.e., `"ukaq"` plus `"imperial"` and `"europe"`).
+#'   - `"ukaq"` will return metadata for all networks for which data is
+#'   imported by [importUKAQ()] (i.e., AURN, AQE, SAQN, WAQN, NI, and the local
+#'   networks).
+#'   - `"all"` will import all available metadata (i.e., `"ukaq"` plus
+#'   `"imperial"` and `"europe"`).
+#'
+#' @param year If a single year is selected, only sites that were open at some
+#'   point in that year are returned. If `all = TRUE` only sites that measured a
+#'   particular pollutant in that year are returned. Year can also be a sequence
+#'   e.g. `year = 2010:2020` or of length 2 e.g. `year = c(2010, 2020)`, which
+#'   will return only sites that were open over the duration.
+#'
+#' @param site,code,site_type Character vectors used to search the metadata for
+#'   the specified `source`s. All of `code`, `site` and `site_type` are
+#'   case-insensitive. `code` and `site_type` are matched exactly, but `site` is
+#'   'pattern matched' - e.g., `site = "Sunderland"` and `source = "aurn"` will
+#'   return data for `"Sunderland"`, `"Sunderland Silksworth"` and `"Sunderland
+#'   Wessington Way"` (plus any future sites with the string `"Sunderland"` in
+#'   their name).
+#'
+#' @param pollutant Character vectors used to search the metadata for the
+#'   specified `source`s. `pollutant` is case-insensitive. For example,
+#'   `pollutant = c("nox", "o3")` will return sites which measure *either* NOx
+#'   *or* O3. Can also take the shorthand `"hc"`, will returns all hydrocarbons.
+#'   Similar to `code`, values are matched exactly (e.g., `pollutant = "no"`
+#'   will only return NO and not NO2 or NOx). Note that `pollutant` only applies
+#'   to networks available through [importUKAQ()].
+#'
+#' @param lat,lng Decimal latitude (`lat`) and longitude (`lng`) (or other Y/X
+#'   coordinate if using a different `crs`). If provided, the data will be
+#'   returned with a `distance_km` column displaying the distance of each
+#'   station from the target coordinate. The data will also be automatically
+#'   sorted by this column.
+#'
+#' @param crs The coordinate reference system (CRS) of the data, passed to
+#'   [sf::st_crs()]. By default this is [EPSG:4326](https://epsg.io/4326), the
+#'   CRS associated with the commonly used latitude and longitude coordinates.
+#'   Different coordinate systems can be specified using `crs` (e.g., `crs =
+#'   27700` for the British National Grid). Note that non-lat/lng coordinate
+#'   systems will be re-projected to EPSG:4326 for comparison with the site
+#'   metadata.
+#'
+#' @param max_dist,max_n If `lat` and `lng` are provided, `max_dist` and `max_n`
+#'   further filter the metadata. `max_dist` defines a maximum distance from the
+#'   target coordinate in kilometers, and `max_n` a maximum number of sites to
+#'   be returned. `max_n` is applied after `max_dist`.
+#'
 #' @param all When `all = FALSE` only the site code, site name, latitude and
 #'   longitude and site type are imported. Setting `all = TRUE` will import all
 #'   available meta data and provide details (when available) or the individual
 #'   pollutants measured at each site.
+#'
 #' @param duplicate Some UK air quality sites are part of multiple networks, so
 #'   could appear more than once when `source` is a vector of two or more. The
 #'   default argument, `FALSE`, drops duplicate sites. `TRUE` will return them.
-#' @param year If a single year is selected, only sites that were open at some
-#'   point in that year are returned. If `all = TRUE` only sites that
-#'   measured a particular pollutant in that year are returned. Year can also be
-#'   a sequence e.g. `year = 2010:2020` or of length 2 e.g. `year =
-#'   c(2010, 2020)`, which will return only sites that were open over the
-#'   duration. Note that `year` is ignored when the `source` is either
-#'   `"imperial"` or `"europe"`.
-#' @return A data frame with meta data.
+#'
+#' @return A data frame
+#'
 #' @author David Carslaw
+#' @author Jack Davison
+#'
 #' @family import functions
+#'
 #' @seealso the `networkMap()` function from the `openairmaps` package which can
 #'   visualise site metadata on an interactive map.
+#'
+#' @references Thanks go to Trevor Davies (WSP), Dr Stuart Grange (EMPA) and Dr
+#'   Ben Barratt (Imperial College) for making these data available.
+#'
 #' @export
 #' @examples
 #' \dontrun{
-#' # basic info:
+#' # Get information for the AURN
 #' meta <- importMeta(source = "aurn")
 #'
-#' # more detailed information:
+#' # More detailed information
 #' meta <- importMeta(source = "aurn", all = TRUE)
 #'
-#' # from the Scottish Air Quality Network:
-#' meta <- importMeta(source = "saqn", all = TRUE)
+#' # From the AURN and SAQN
+#' meta <- importMeta(source = c("aurn", "saqn"))
 #'
-#' # from multiple networks:
-#' meta <- importMeta(source = c("aurn", "aqe", "local"))
+#' # Sites in the UK measuring SO2 or CO
+#' meta <- importMeta(source = "ukaq", pollutant = c("so2", "co"))
+#'
+#' # English sites within 5km of Buckingham Palace
+#' meta <- importMeta(
+#'   source = c("aurn", "aqe", "local"),
+#'   lat = 51.50101,
+#'   lng = -0.141563,
+#'   max_dist = 5
+#' )
 #' }
 importMeta <-
-  function(source = "aurn", all = FALSE, year = NA, duplicate = FALSE) {
-    ## special source arguments
+  function(
+    source = "aurn",
+    year = NULL,
+    pollutant = NULL,
+    code = NULL,
+    site = NULL,
+    site_type = NULL,
+    lat = NULL,
+    lng = NULL,
+    crs = 4326,
+    max_dist = NULL,
+    max_n = NULL,
+    all = FALSE,
+    duplicate = FALSE
+  ) {
+    if (!is.null(year) && is.na(year)) {
+      year <- NULL
+    }
+
+    # ensure lower case
+    source <- tolower(source)
+
+    # alias source arguments
+    source[source == "kcl"] <- "imperial"
+    source[source == "saqd"] <- "saqn"
+    source[source == "niaqn"] <- "ni"
+    source[source == "lmam"] <- "local"
+
+    # special source args
     if (any(source == "ukaq")) {
       source <- c("aurn", "aqe", "saqn", "waqn", "ni", "local")
     }
@@ -110,37 +243,25 @@ importMeta <-
         c("aurn", "aqe", "saqn", "waqn", "ni", "local", "imperial", "europe")
     }
 
-    ## meta data sources
-    meta.source <-
+    # check sources are valid
+    source <- rlang::arg_match(
+      source,
       c(
         "aurn",
-        "kcl",
         "imperial",
         "saqn",
-        "saqd",
         "waqn",
         "aqe",
         "local",
-        "lmam",
         "ni",
         "europe"
-      )
-
-    ## ensure lower case
-    source <- tolower(source)
-
-    if (!all(source %in% meta.source)) {
-      cli::cli_abort(
-        c(
-          "!" = '"{source}" not a recognised {.field source}.',
-          "i" = "{.field source} can be any of {.or {meta.source}}."
-        )
-      )
-    }
+      ),
+      multiple = TRUE
+    )
 
     # function to import any of the source networks
     get_meta <- function(source, all) {
-      if (!source %in% c("kcl", "imperial", "europe")) {
+      if (!source %in% c("imperial", "europe")) {
         url <- switch(
           source,
           aurn = "https://uk-air.defra.gov.uk/openair/R_data/AURN_metadata.RData",
@@ -153,104 +274,37 @@ importMeta <-
           lmam = "https://uk-air.defra.gov.uk/openair/LMAM/R_data/LMAM_metadata.RData"
         )
 
-        meta <- clean_ricardo_meta(url, all = all, year = year)
+        meta <- read_wsp_meta(
+          url,
+          all = all,
+          year = year,
+          pollutant = pollutant
+        )
       }
 
       # KCL
-      if (source %in% c("kcl", "imperial")) {
-        con <- url("https://londonair.org.uk/r_data/sites.RData")
-        meta <- get(load(con))
-        close(con)
-
-        ## rename to match imported names e.g. importKCL
-        meta <- dplyr::rename(
-          meta,
-          code = "SiteCode",
-          site = "SiteName",
-          site_type = "Classification",
-          latitude = "Latitude",
-          longitude = "Longitude"
+      if (source == "imperial") {
+        meta <- read_imperial_meta(
+          "https://londonair.org.uk/r_data/sites.RData",
+          all = all,
+          year = year
         )
-
-        # select year or period when sites were open
-        if (!anyNA(year)) {
-          # format end_date - set "ongoing" to current date
-          meta$end_year <-
-            lubridate::year(as.Date(meta$ClosingDate))
-          meta$end_year <-
-            ifelse(
-              is.na(meta$end_year),
-              as.numeric(format(Sys.Date(), "%Y")),
-              meta$end_year
-            )
-          meta$start_year <- lubridate::year(meta$OpeningDate)
-          meta <-
-            dplyr::filter(
-              meta,
-              .data$start_year <= min(year) &
-                .data$end_year >= max(year)
-            )
-        }
       }
 
       # EUROPE
       if (source == "europe") {
-        file <-
-          "http://aq-data.ricardo-aea.com/R_data/saqgetr/helper_tables/sites_table.csv.gz"
-
-        # Define data types
-        col_types <- readr::cols(
-          site = readr::col_character(),
-          site_name = readr::col_character(),
-          latitude = readr::col_double(),
-          longitude = readr::col_double(),
-          elevation = readr::col_double(),
-          country = readr::col_character(),
-          country_iso_code = readr::col_character(),
-          site_type = readr::col_character(),
-          site_area = readr::col_character(),
-          date_start = readr::col_character(),
-          date_end = readr::col_character(),
-          network = readr::col_character(),
-          eu_code = readr::col_character(),
-          eoi_code = readr::col_character(),
-          data_source = readr::col_character()
+        meta <- read_saqgetr_meta(
+          "http://aq-data.ricardo-aea.com/R_data/saqgetr/helper_tables/sites.gz",
+          year = year
         )
-
-        # Read data and parse dates
-        meta <-
-          readr::read_csv(file, col_types = col_types, progress = FALSE) |>
-          dplyr::mutate(
-            date_start = lubridate::ymd_hms(.data$date_start, tz = "UTC"),
-            date_end = lubridate::ymd_hms(.data$date_end, tz = "UTC")
-          )
-
-        # select year or period when sites were open
-        if (!anyNA(year)) {
-          # format end_date - set "ongoing" to current date
-          meta$end_year <-
-            lubridate::year(as.Date(meta$date_end))
-          meta$end_year <-
-            ifelse(
-              is.na(meta$end_year),
-              as.numeric(format(Sys.Date(), "%Y")),
-              meta$end_year
-            )
-          meta$start_year <- lubridate::year(meta$date_start)
-          meta <-
-            dplyr::filter(
-              meta,
-              .data$start_year <= min(year) &
-                .data$end_year >= max(year)
-            )
-        }
-
-        meta <- dplyr::rename(meta, code = "site", site = "site_name")
       }
 
       # return data source
-      meta <-
-        dplyr::mutate(meta, source = source, .before = dplyr::everything())
+      meta <- dplyr::mutate(
+        meta,
+        source = source,
+        .before = dplyr::everything()
+      )
 
       return(meta)
     }
@@ -258,7 +312,53 @@ importMeta <-
     # import meta data
     meta <-
       purrr::map(.x = source, .f = ~ get_meta(source = .x, all = all)) |>
-      purrr::list_rbind()
+      purrr::list_rbind() |>
+      dplyr::tibble()
+
+    if (nrow(meta) == 0) {
+      warn_empty_meta()
+      return(meta)
+    }
+
+    # filter code
+    if (!is.null(code) && "code" %in% names(meta)) {
+      meta <- dplyr::filter(
+        meta,
+        tolower(.data$code) %in% tolower({{ code }})
+      )
+
+      if (nrow(meta) == 0) {
+        warn_empty_meta()
+        return(meta)
+      }
+    }
+
+    # search site name
+    if (!is.null(site) && "site" %in% names(meta)) {
+      all_sites <- paste(site, collapse = "|")
+      meta <- dplyr::filter(
+        meta,
+        grepl(!!all_sites, .data$site, ignore.case = TRUE)
+      )
+
+      if (nrow(meta) == 0) {
+        warn_empty_meta()
+        return(meta)
+      }
+    }
+
+    # search site type
+    if (!is.null(site_type) && "site_type" %in% names(meta)) {
+      meta <- dplyr::filter(
+        meta,
+        tolower(.data$site_type) %in% tolower({{ site_type }})
+      )
+
+      if (nrow(meta) == 0) {
+        warn_empty_meta()
+        return(meta)
+      }
+    }
 
     # drop extra columns if not "all"
     if (!all) {
@@ -276,15 +376,6 @@ importMeta <-
             )
           )
         )
-    }
-
-    # change some names
-    if ("variable" %in% names(meta)) {
-      id <- which(meta$variable == "NOXasNO2")
-
-      if (length(id) > 0) {
-        meta$variable[id] <- "NOx"
-      }
     }
 
     # deal with duplicates
@@ -309,15 +400,69 @@ importMeta <-
       }
     }
 
-    dplyr::as_tibble(meta)
+    # spatial filtering
+    if (!is.null(lat) && !is.null(lng)) {
+      target <- sf::st_as_sf(
+        dplyr::tibble(lat = lat, lng = lng),
+        coords = c("lng", "lat"),
+        crs = crs
+      ) |>
+        sf::st_transform(crs = 4326)
+
+      meta_old <- meta
+      meta <- tidyr::drop_na(meta, dplyr::all_of(c("latitude", "longitude")))
+
+      if (nrow(meta) != nrow(meta_old)) {
+        cli::cli_warn(
+          "Dropping {nrow(meta_old) - nrow(meta)} station{?s} \\
+                      with missing latitude & longitude."
+        )
+      }
+
+      meta_sf <- sf::st_as_sf(
+        meta,
+        coords = c("longitude", "latitude"),
+        crs = 4326,
+        remove = FALSE
+      )
+
+      meta_sf$distance_km <- as.numeric(sf::st_distance(meta_sf, target)) / 1000
+
+      # add distance column, drop geometry
+      meta <- dplyr::arrange(meta_sf, .data$distance_km) |>
+        sf::st_drop_geometry()
+
+      # filter max distance
+      if (!is.null(max_dist)) {
+        meta <- dplyr::filter(meta, .data$distance_km <= max_dist)
+        if (nrow(meta) == 0) {
+          warn_empty_meta()
+          return(meta)
+        }
+      }
+
+      # filter max number
+      if (!is.null(max_n)) {
+        # need semi_join approach as could have multiple rows per site when all
+        # = TRUE
+        max_n_sites <-
+          meta |>
+          dplyr::distinct(source, code, distance_km) |>
+          dplyr::slice_min(
+            order_by = .data$distance_km,
+            n = max_n,
+            with_ties = TRUE
+          )
+
+        meta <- dplyr::semi_join(meta, max_n_sites, by = c("source", "code"))
+      }
+    }
+
+    dplyr::tibble(meta)
   }
 
-#' Clean data from Ricardo (not KCL or Europe)
-#' @param url URL to use
-#' @param all inherited from parent function
-#' @param year inherited from parent function
-#' @noRd
-clean_ricardo_meta <- function(url, all, year) {
+# Read data from WSP's networks
+read_wsp_meta <- function(url, all, year, pollutant) {
   tmp <- tempfile()
 
   # load data
@@ -339,6 +484,11 @@ clean_ricardo_meta <- function(url, all, year) {
         pattern = "Urban traffic",
         replacement = "Urban Traffic",
         .data$site_type
+      ),
+      site_type = gsub(
+        pattern = "unknown unknown",
+        replacement = "Unknown",
+        .data$site_type
       )
     )
 
@@ -349,7 +499,7 @@ clean_ricardo_meta <- function(url, all, year) {
   }
 
   # select year or period when sites were open
-  if (!anyNA(year)) {
+  if (!is.null(year)) {
     # format end_date - set "ongoing" to current date
     meta$end_date[which(meta$end_date == "ongoing")] <-
       as.character(Sys.Date())
@@ -363,11 +513,177 @@ clean_ricardo_meta <- function(url, all, year) {
       )
   }
 
-  ## only extract one line per site to make it easier to use file
-  ## mostly interested in coordinates
+  # change some variable names
+  meta$variable[meta$variable == "NOXasNO2"] <- "NOx"
+
+  # filter for pollutant
+  if (!is.null(pollutant)) {
+    if ("hc" %in% pollutant) {
+      pollutant <- c(
+        pollutant,
+        c(
+          "ETHANE",
+          "ETHENE",
+          "ETHYNE",
+          "PROPANE",
+          "PROPENE",
+          "iBUTANE",
+          "nBUTANE",
+          "1BUTENE",
+          "t2BUTENE",
+          "c2BUTENE",
+          "iPENTANE",
+          "nPENTANE",
+          "13BDIENE",
+          "t2PENTEN",
+          "1PENTEN",
+          "c2PENTEN",
+          "2MEPENT",
+          "3MEPENT",
+          "ISOPRENE",
+          "nHEXANE",
+          "nHEPTANE",
+          "iOCTANE",
+          "nOCTANE",
+          "BENZENE",
+          "TOLUENE",
+          "ETHBENZ",
+          "mpXYLENE",
+          "oXYLENE",
+          "123TMB",
+          "124TMB",
+          "135TMB"
+        )
+      )
+      pollutant <- pollutant[pollutant != "hc"]
+    }
+
+    meta <- dplyr::filter(
+      meta,
+      tolower(.data$variable) %in% tolower({{ pollutant }})
+    )
+  }
+
+  # only extract one line per site to make it easier to use file
+  # mostly interested in coordinates
   if (!all) {
     meta <- dplyr::distinct(meta, .data$site, .keep_all = TRUE)
   }
 
   return(meta)
+}
+
+# read metadata from Imperial College London
+read_imperial_meta <- function(url, all, year) {
+  con <- url(url)
+  meta <- get(load(con))
+  close(con)
+
+  ## rename to match imported names e.g. importKCL
+  meta <- dplyr::rename(
+    meta,
+    code = "SiteCode",
+    site = "SiteName",
+    site_type = "Classification",
+    latitude = "Latitude",
+    longitude = "Longitude"
+  )
+
+  # select year or period when sites were open
+  if (!is.null(year)) {
+    # format end_date - set "ongoing" to current date
+    meta$end_year <-
+      lubridate::year(as.Date(meta$ClosingDate))
+    meta$end_year <-
+      ifelse(
+        is.na(meta$end_year),
+        as.numeric(format(Sys.Date(), "%Y")),
+        meta$end_year
+      )
+    meta$start_year <- lubridate::year(meta$OpeningDate)
+    meta <-
+      dplyr::filter(
+        meta,
+        .data$start_year <= min(year) &
+          .data$end_year >= max(year)
+      )
+  }
+
+  meta
+}
+
+# read data from the saqgetr database
+read_saqgetr_meta <- function(url, year) {
+  msg <-
+    c(
+      "!" = "{.fun importEurope} has been discontinued and cannot import \\
+      data after February 2024.",
+      "i" = "Consider using the EEA Air Quality Download Service \\
+      instead {.url https://eeadmz1-downloads-webapp.azurewebsites.net/}"
+    )
+
+  cli::cli_inform(msg, .frequency = "regularly", .frequency_id = "europe")
+
+  # Define data types
+  col_types <- readr::cols(
+    site = readr::col_character(),
+    site_name = readr::col_character(),
+    latitude = readr::col_double(),
+    longitude = readr::col_double(),
+    elevation = readr::col_double(),
+    country = readr::col_character(),
+    country_iso_code = readr::col_character(),
+    site_type = readr::col_character(),
+    site_area = readr::col_character(),
+    date_start = readr::col_character(),
+    date_end = readr::col_character(),
+    network = readr::col_character(),
+    eu_code = readr::col_character(),
+    eoi_code = readr::col_character(),
+    data_source = readr::col_character()
+  )
+
+  # Read data and parse dates
+  meta <-
+    readr::read_csv(url, col_types = col_types, progress = FALSE) |>
+    dplyr::mutate(
+      date_start = lubridate::ymd_hms(.data$date_start, tz = "UTC"),
+      date_end = lubridate::ymd_hms(.data$date_end, tz = "UTC")
+    )
+
+  # select year or period when sites were open
+  if (!is.null(year)) {
+    # format end_date - set "ongoing" to current date
+    meta$end_year <-
+      lubridate::year(as.Date(meta$date_end))
+    meta$end_year <-
+      ifelse(
+        is.na(meta$end_year),
+        as.numeric(format(Sys.Date(), "%Y")),
+        meta$end_year
+      )
+    meta$start_year <- lubridate::year(meta$date_start)
+    meta <-
+      dplyr::filter(
+        meta,
+        .data$start_year <= min(year) &
+          .data$end_year >= max(year)
+      )
+  }
+
+  # rename some variables
+  meta <- dplyr::rename(meta, code = "site", site = "site_name")
+
+  meta
+}
+
+# Shared warning message if all data has been filtered away
+warn_empty_meta <- function() {
+  cli::cli_warn(
+    c(
+      "!" = "No metadata has been returned.",
+      "i" = "Check the {.arg year}, {.arg code}, {.arg site}, \\
+      {.arg pollutant} and/or {.arg max_dist} arguments."
+    )
+  )
 }

--- a/R/importTraj.R
+++ b/R/importTraj.R
@@ -97,10 +97,10 @@
 #'   use `year = c(1990, 1995, 2000)` for example.
 #'
 #' @param local File path to .RData trajectory files run by user and
-#' not stored on the Ricardo web server. These files would have been
+#' not stored on the WSP web server. These files would have been
 #' generated from the Hysplit trajectory code shown in the appendix
 #' of the openair manual. An example would be `local =
-#' 'c:/users/david/TrajFiles/'`.
+#' 'C:/Users/David/TrajFiles/'`.
 #' @export
 #' @return Returns a data frame with pre-calculated back trajectories.
 #' @author David Carslaw

--- a/R/importUKAQ-utils.R
+++ b/R/importUKAQ-utils.R
@@ -1,4 +1,4 @@
-#' worker function that downloads data from a range of networks run by Ricardo
+#' worker function that downloads data from a range of networks run by WSP
 #' @noRd
 readUKAQData <-
   function(

--- a/R/importUKAQ.R
+++ b/R/importUKAQ.R
@@ -4,17 +4,17 @@
 #' including the Automatic Urban and Rural Network (AURN), the individual
 #' England (AQE), Scotland (SAQN), Wales (WAQN) and Northern Ireland (NI)
 #' Networks, and many "locally managed" monitoring networks across England.
-#' Files are imported from a remote server operated by Ricardo that provides air
+#' Files are imported from a remote server operated by WSP that provides air
 #' quality data files as R data objects. For an up to date list of available
 #' sites that can be imported, see [importMeta()].
 #'
 #' @section Importing UK Air Pollution Data:
 #'
 #'   This family of functions has been written to make it easy to import data
-#'   from across several UK air quality networks. Ricardo have provided .RData
-#'   files (R workspaces) of all individual sites and years, as well as up to
-#'   date meta data. These files are updated on a daily basis. This approach
-#'   requires a link to the Internet to work.
+#'   from across several UK air quality networks. WSP have provided .RData files
+#'   (R workspaces) of all individual sites and years, as well as up to date
+#'   meta data. These files are updated on a daily basis. This approach requires
+#'   a link to the Internet to work.
 #'
 #'   There are several advantages over the web portal approach where .csv files
 #'   are downloaded.
@@ -69,7 +69,7 @@
 #'   The function returns modelled hourly values of wind speed (`ws`), wind
 #'   direction (`wd`) and ambient temperature (`air_temp`) if available
 #'   (generally from around 2010). These values are modelled using the WRF model
-#'   operated by Ricardo.
+#'   operated by WSP.
 #'
 #'   The BAM (Beta-Attenuation Monitor) instruments that have been incorporated
 #'   into the network throughout its history have been scaled by 1.3 if they
@@ -135,10 +135,9 @@
 #' @param meteo Append modelled meteorological data, if available? Defaults to
 #'   `TRUE`, which will return wind speed (`ws`), wind direction (`wd`) and
 #'   ambient temperature (`air_temp`). The variables are calculated from using
-#'   the WRF model run by Ricardo Energy & Environment and are available for
-#'   most but not all networks. Setting `meteo = FALSE` is useful if you have
-#'   other meteorological data to use in preference, for example from the
-#'   `worldmet` package.
+#'   the WRF model run by WSP and are available for most but not all networks.
+#'   Setting `meteo = FALSE` is useful if you have other meteorological data to
+#'   use in preference, for example from the `worldmet` package.
 #' @param ratified Append `qc` column(s) to hourly data indicating whether each
 #'   species was ratified (i.e., quality-checked)?  Defaults to `FALSE`.
 #' @param to_narrow Return the data in a "narrow"/"long"/"tidy" format? By

--- a/man/importMeta.Rd
+++ b/man/importMeta.Rd
@@ -4,7 +4,21 @@
 \alias{importMeta}
 \title{Import monitoring site meta data for UK and European networks}
 \usage{
-importMeta(source = "aurn", all = FALSE, year = NA, duplicate = FALSE)
+importMeta(
+  source = "aurn",
+  year = NULL,
+  pollutant = NULL,
+  code = NULL,
+  site = NULL,
+  site_type = NULL,
+  lat = NULL,
+  lng = NULL,
+  crs = 4326,
+  max_dist = NULL,
+  max_n = NULL,
+  all = FALSE,
+  duplicate = FALSE
+)
 }
 \arguments{
 \item{source}{One or more air quality networks for which data is available
@@ -22,28 +36,63 @@ through openair. Available networks include:
 
 There are two additional options provided for convenience:
 \itemize{
-\item \code{"ukaq"} will return metadata for all networks for which data is imported by \code{\link[=importUKAQ]{importUKAQ()}} (i.e., AURN, AQE, SAQN, WAQN, NI, and the local networks).
-\item \code{"all"} will import all available metadata (i.e., \code{"ukaq"} plus \code{"imperial"} and \code{"europe"}).
+\item \code{"ukaq"} will return metadata for all networks for which data is
+imported by \code{\link[=importUKAQ]{importUKAQ()}} (i.e., AURN, AQE, SAQN, WAQN, NI, and the local
+networks).
+\item \code{"all"} will import all available metadata (i.e., \code{"ukaq"} plus
+\code{"imperial"} and \code{"europe"}).
 }}
+
+\item{year}{If a single year is selected, only sites that were open at some
+point in that year are returned. If \code{all = TRUE} only sites that measured a
+particular pollutant in that year are returned. Year can also be a sequence
+e.g. \code{year = 2010:2020} or of length 2 e.g. \code{year = c(2010, 2020)}, which
+will return only sites that were open over the duration.}
+
+\item{pollutant}{Character vectors used to search the metadata for the
+specified \code{source}s. \code{pollutant} is case-insensitive. For example,
+\code{pollutant = c("nox", "o3")} will return sites which measure \emph{either} NOx
+\emph{or} O3. Can also take the shorthand \code{"hc"}, will returns all hydrocarbons.
+Similar to \code{code}, values are matched exactly (e.g., \code{pollutant = "no"}
+will only return NO and not NO2 or NOx). Note that \code{pollutant} only applies
+to networks available through \code{\link[=importUKAQ]{importUKAQ()}}.}
+
+\item{site, code, site_type}{Character vectors used to search the metadata for
+the specified \code{source}s. All of \code{code}, \code{site} and \code{site_type} are
+case-insensitive. \code{code} and \code{site_type} are matched exactly, but \code{site} is
+'pattern matched' - e.g., \code{site = "Sunderland"} and \code{source = "aurn"} will
+return data for \code{"Sunderland"}, \code{"Sunderland Silksworth"} and \code{"Sunderland Wessington Way"} (plus any future sites with the string \code{"Sunderland"} in
+their name).}
+
+\item{lat, lng}{Decimal latitude (\code{lat}) and longitude (\code{lng}) (or other Y/X
+coordinate if using a different \code{crs}). If provided, the data will be
+returned with a \code{distance_km} column displaying the distance of each
+station from the target coordinate. The data will also be automatically
+sorted by this column.}
+
+\item{crs}{The coordinate reference system (CRS) of the data, passed to
+\code{\link[sf:st_crs]{sf::st_crs()}}. By default this is \href{https://epsg.io/4326}{EPSG:4326}, the
+CRS associated with the commonly used latitude and longitude coordinates.
+Different coordinate systems can be specified using \code{crs} (e.g., \code{crs = 27700} for the British National Grid). Note that non-lat/lng coordinate
+systems will be re-projected to EPSG:4326 for comparison with the site
+metadata.}
+
+\item{max_dist, max_n}{If \code{lat} and \code{lng} are provided, \code{max_dist} and \code{max_n}
+further filter the metadata. \code{max_dist} defines a maximum distance from the
+target coordinate in kilometers, and \code{max_n} a maximum number of sites to
+be returned. \code{max_n} is applied after \code{max_dist}.}
 
 \item{all}{When \code{all = FALSE} only the site code, site name, latitude and
 longitude and site type are imported. Setting \code{all = TRUE} will import all
 available meta data and provide details (when available) or the individual
 pollutants measured at each site.}
 
-\item{year}{If a single year is selected, only sites that were open at some
-point in that year are returned. If \code{all = TRUE} only sites that
-measured a particular pollutant in that year are returned. Year can also be
-a sequence e.g. \code{year = 2010:2020} or of length 2 e.g. \code{year = c(2010, 2020)}, which will return only sites that were open over the
-duration. Note that \code{year} is ignored when the \code{source} is either
-\code{"imperial"} or \code{"europe"}.}
-
 \item{duplicate}{Some UK air quality sites are part of multiple networks, so
 could appear more than once when \code{source} is a vector of two or more. The
 default argument, \code{FALSE}, drops duplicate sites. \code{TRUE} will return them.}
 }
 \value{
-A data frame with meta data.
+A data frame
 }
 \description{
 Function to import meta data for air quality monitoring sites. By default,
@@ -51,7 +100,9 @@ the function will return the site latitude, longitude and site type, as well
 as the code used in functions like \code{\link[=importUKAQ]{importUKAQ()}}, \code{\link[=importImperial]{importImperial()}} and
 \code{\link[=importEurope]{importEurope()}}. Additional information may optionally be returned.
 }
-\details{
+\section{Available Networks}{
+
+
 This function imports site meta data from several networks in the UK and
 Europe:
 \itemize{
@@ -60,45 +111,101 @@ Europe:
 \item \code{"saqn"},  The \href{https://www.scottishairquality.scot/}{Scottish Air Quality Network}.
 \item \code{"waqn"},  The \href{https://airquality.gov.wales/}{Welsh Air Quality Network}.
 \item \code{"ni"},  The \href{https://www.airqualityni.co.uk/}{Northern Ireland Air Quality Network}.
-\item \code{"local"},  \href{https://uk-air.defra.gov.uk/networks/network-info?view=nondefraaqmon}{Locally managed} air quality networks in England.
+\item \code{"local"},  \href{https://uk-air.defra.gov.uk/networks/network-info?view=nondefraaqmon}{Locally managed}
+air quality networks in England.
 \item \code{"imperial"},  Imperial College London (formerly King's College London) networks.
 \item \code{"europe"},  Hourly European data (Air Quality e-Reporting) based on a
-simplified version of the \code{{saqgetr}} package.
+simplified version of the \code{{saqgetr}} package. Note that this data is only
+available until February 2024; see \code{\link[=importEurope]{importEurope()}} for more information.
 }
+}
+
+\section{Order of Operations}{
+
+
+This function contains various arguments which allow the user to filter the
+metadata before it is returned. These arguments are applied in the
+following order:
+\itemize{
+\item \code{source}
+\item \code{year}
+\item \code{pollutant} (where possible)
+\item \code{code}
+\item \code{site}
+\item \code{site_type}
+\item \code{max_dist}
+\item \code{max_n}
+}
+
+Note that \code{max_n} is not \emph{always} the number of rows returned by the
+function; it is the maximum number of possible sites to be returned. If
+\code{all = TRUE}, multiple rows will be present per site. Further, if previous
+filtering steps mean that fewer than \code{max_n} sites are remaining in the
+data, \code{max_n} will have no effect.
+
+If the combination of arguments provided results in the removal of all
+sites, this function will return an empty dataframe with a warning.
+}
+
+\section{Data Dictionary}{
+
 
 By default, the function will return the site latitude, longitude and site
 type. If the option \code{all = TRUE} is used, much more detailed information is
-returned. The following metadata columns are available in the complete dataset:
+returned. The following metadata columns are available in the complete
+dataset:
 \itemize{
-\item \strong{source}: The network with which the site is associated. Note that some monitoring sites are part of multiple networks (e.g., the AURN & SAQN) so the same site may feature twice under different sources.
-\item \strong{code}: The site code, used to import data from specific sites of interest.
+\item \strong{source}: The network with which the site is associated. Note that
+some monitoring sites are part of multiple networks (e.g., the AURN & SAQN)
+so the same site may feature twice under different sources.
+\item \strong{code}: The site code, used to import data from specific sites of
+interest.
 \item \strong{site}: The site name, which is more human-readable than the site code.
-\item \strong{site_type}: A description of the site environment. Read more at \url{https://uk-air.defra.gov.uk/networks/site-types}.
-\item \strong{latitude} and \strong{longitude}: The coordinates of the monitoring station, using the World Geodetic System (\url{https://epsg.io/4326}).
-\item \strong{start_date} and \strong{end_date}: The opening and closing dates of the monitoring station. If \code{by_pollutant = TRUE}, these dates are instead the first and last dates at which specific pollutants were measured. A missing value, \code{NA}, indicates that monitoring is ongoing.
-\item \strong{ratified_to}: The date to which data has been ratified (i.e., 'quality checked'). Data after this date is subject to change.
-\item \strong{zone} and \strong{agglomeration}: The UK is divided into agglomeration zones (large urban areas) and non-agglomeration zones for air quality assessment, which are given in these columns.
-\item \strong{local_authority}: The local authority in which the monitoring station is found.
-\item \strong{provider} and \strong{code}: The specific provider of the locally managed dataset (e.g., \code{"londonair"}).
+\item \strong{site_type}: A description of the site environment.
+\item \strong{latitude} and \strong{longitude}: The coordinates of the monitoring
+station, using the World Geodetic System (\url{https://epsg.io/4326}).
+\item \strong{start_date} and \strong{end_date}: The opening and closing dates of the
+monitoring station. If \code{by_pollutant = TRUE}, these dates are instead the
+first and last dates at which specific pollutants were measured. A missing
+value, \code{NA}, indicates that monitoring is ongoing.
+\item \strong{ratified_to}: The date to which data has been ratified
+(i.e., 'quality checked'). Data after this date is subject to change.
+\item \strong{zone} and \strong{agglomeration}: The UK is divided into agglomeration
+zones (large urban areas) and non-agglomeration zones for air quality
+assessment, which are given in these columns.
+\item \strong{local_authority}: The local authority in which the monitoring station
+is found.
+\item \strong{provider} and \strong{code}: The specific provider of the locally
+managed dataset (e.g., \code{"londonair"}).
+}
 }
 
-Thanks go to Trevor Davies (Ricardo), Dr Stuart Grange (EMPA) and Dr Ben
-Barratt (KCL) and  for making these data available.
-}
 \examples{
 \dontrun{
-# basic info:
+# Get information for the AURN
 meta <- importMeta(source = "aurn")
 
-# more detailed information:
+# More detailed information
 meta <- importMeta(source = "aurn", all = TRUE)
 
-# from the Scottish Air Quality Network:
-meta <- importMeta(source = "saqn", all = TRUE)
+# From the AURN and SAQN
+meta <- importMeta(source = c("aurn", "saqn"))
 
-# from multiple networks:
-meta <- importMeta(source = c("aurn", "aqe", "local"))
+# Sites in the UK measuring SO2 or CO
+meta <- importMeta(source = "ukaq", pollutant = c("so2", "co"))
+
+# English sites within 5km of Buckingham Palace
+meta <- importMeta(
+  source = c("aurn", "aqe", "local"),
+  lat = 51.50101,
+  lng = -0.141563,
+  max_dist = 5
+)
 }
+}
+\references{
+Thanks go to Trevor Davies (WSP), Dr Stuart Grange (EMPA) and Dr
+Ben Barratt (Imperial College) for making these data available.
 }
 \seealso{
 the \code{networkMap()} function from the \code{openairmaps} package which can
@@ -114,5 +221,7 @@ Other import functions:
 }
 \author{
 David Carslaw
+
+Jack Davison
 }
 \concept{import functions}

--- a/man/importTraj.Rd
+++ b/man/importTraj.Rd
@@ -54,9 +54,9 @@ yw         \tab Yarner Wood                  \tab  50.59760 \tab  -3.716510 \tab
 use \code{year = c(1990, 1995, 2000)} for example.}
 
 \item{local}{File path to .RData trajectory files run by user and
-not stored on the Ricardo web server. These files would have been
+not stored on the WSP web server. These files would have been
 generated from the Hysplit trajectory code shown in the appendix
-of the openair manual. An example would be \code{local = 'c:/users/david/TrajFiles/'}.}
+of the openair manual. An example would be \code{local = 'C:/Users/David/TrajFiles/'}.}
 
 \item{progress}{Show a progress bar when many receptors/years are being
 imported? Defaults to \code{TRUE}.}

--- a/man/importUKAQ-wrapper.Rd
+++ b/man/importUKAQ-wrapper.Rd
@@ -134,10 +134,9 @@ Defaults to site type, latitude and longitude. Can be any of \code{"site_type"},
 \item{meteo}{Append modelled meteorological data, if available? Defaults to
 \code{TRUE}, which will return wind speed (\code{ws}), wind direction (\code{wd}) and
 ambient temperature (\code{air_temp}). The variables are calculated from using
-the WRF model run by Ricardo Energy & Environment and are available for
-most but not all networks. Setting \code{meteo = FALSE} is useful if you have
-other meteorological data to use in preference, for example from the
-\code{worldmet} package.}
+the WRF model run by WSP and are available for most but not all networks.
+Setting \code{meteo = FALSE} is useful if you have other meteorological data to
+use in preference, for example from the \code{worldmet} package.}
 
 \item{ratified}{Append \code{qc} column(s) to hourly data indicating whether each
 species was ratified (i.e., quality-checked)?  Defaults to \code{FALSE}.}
@@ -169,10 +168,10 @@ are provided for convenience and back-compatibility.
 
 
 This family of functions has been written to make it easy to import data
-from across several UK air quality networks. Ricardo have provided .RData
-files (R workspaces) of all individual sites and years, as well as up to
-date meta data. These files are updated on a daily basis. This approach
-requires a link to the Internet to work.
+from across several UK air quality networks. WSP have provided .RData files
+(R workspaces) of all individual sites and years, as well as up to date
+meta data. These files are updated on a daily basis. This approach requires
+a link to the Internet to work.
 
 There are several advantages over the web portal approach where .csv files
 are downloaded.
@@ -224,7 +223,7 @@ latter corresponding to daily gravimetric measurements.
 The function returns modelled hourly values of wind speed (\code{ws}), wind
 direction (\code{wd}) and ambient temperature (\code{air_temp}) if available
 (generally from around 2010). These values are modelled using the WRF model
-operated by Ricardo.
+operated by WSP.
 
 The BAM (Beta-Attenuation Monitor) instruments that have been incorporated
 into the network throughout its history have been scaled by 1.3 if they

--- a/man/importUKAQ.Rd
+++ b/man/importUKAQ.Rd
@@ -80,10 +80,9 @@ Defaults to site type, latitude and longitude. Can be any of \code{"site_type"},
 \item{meteo}{Append modelled meteorological data, if available? Defaults to
 \code{TRUE}, which will return wind speed (\code{ws}), wind direction (\code{wd}) and
 ambient temperature (\code{air_temp}). The variables are calculated from using
-the WRF model run by Ricardo Energy & Environment and are available for
-most but not all networks. Setting \code{meteo = FALSE} is useful if you have
-other meteorological data to use in preference, for example from the
-\code{worldmet} package.}
+the WRF model run by WSP and are available for most but not all networks.
+Setting \code{meteo = FALSE} is useful if you have other meteorological data to
+use in preference, for example from the \code{worldmet} package.}
 
 \item{ratified}{Append \code{qc} column(s) to hourly data indicating whether each
 species was ratified (i.e., quality-checked)?  Defaults to \code{FALSE}.}
@@ -110,7 +109,7 @@ Functions for importing air pollution data from a range of UK networks
 including the Automatic Urban and Rural Network (AURN), the individual
 England (AQE), Scotland (SAQN), Wales (WAQN) and Northern Ireland (NI)
 Networks, and many "locally managed" monitoring networks across England.
-Files are imported from a remote server operated by Ricardo that provides air
+Files are imported from a remote server operated by WSP that provides air
 quality data files as R data objects. For an up to date list of available
 sites that can be imported, see \code{\link[=importMeta]{importMeta()}}.
 }
@@ -118,10 +117,10 @@ sites that can be imported, see \code{\link[=importMeta]{importMeta()}}.
 
 
 This family of functions has been written to make it easy to import data
-from across several UK air quality networks. Ricardo have provided .RData
-files (R workspaces) of all individual sites and years, as well as up to
-date meta data. These files are updated on a daily basis. This approach
-requires a link to the Internet to work.
+from across several UK air quality networks. WSP have provided .RData files
+(R workspaces) of all individual sites and years, as well as up to date
+meta data. These files are updated on a daily basis. This approach requires
+a link to the Internet to work.
 
 There are several advantages over the web portal approach where .csv files
 are downloaded.
@@ -173,7 +172,7 @@ latter corresponding to daily gravimetric measurements.
 The function returns modelled hourly values of wind speed (\code{ws}), wind
 direction (\code{wd}) and ambient temperature (\code{air_temp}) if available
 (generally from around 2010). These values are modelled using the WRF model
-operated by Ricardo.
+operated by WSP.
 
 The BAM (Beta-Attenuation Monitor) instruments that have been incorporated
 into the network throughout its history have been scaled by 1.3 if they


### PR DESCRIPTION
This PR adds `worldmet::import_ghcn_stations()`-esque arguments to `openair::importMeta()`. This includes searching by site name, code, site type, pollutants measured, and the distance from a target coordinate.

I think this will be particularly useful for EIA work, and to examine potential AQ episodes local to an incident.

Separately, this will allow `searchNetwork()` to be superseded in `openairmaps`, as all the functionality will now sit in `importMeta()` and `networkMap()`.