### PR TITLE
feat: allow parallel import of UKAQ data with `mirai`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Imports:
     methods,
     mgcv,
     patchwork,
-    purrr (>= 1.0.0),
+    purrr (>= 1.1.0),
     Rcpp,
     readr,
     rlang,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,10 +43,12 @@ Imports:
     tidyr,
     utils
 Suggests:
+    carrier,
     geomtextpath,
     KernSmooth,
     knitr,
     legendry (>= 0.2.4),
+    mirai,
     quantreg,
     rmarkdown,
     rnaturalearth,
@@ -57,10 +59,10 @@ LinkingTo:
     Rcpp
 ByteCompile: true
 Config/Needs/website: openair-project/openairpkgdown
+Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-GB
 LazyData: yes
 LazyLoad: yes
 Roxygen: list(markdown = TRUE)
-Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # openair (development version)
 
+## Dependency Changes
+
+- `{openair}` now suggests `{mirai}` and `{carrier}`.
+
 ## New Features
 
 - All plots gain the `theme` argument to provide a convenient way to set non-data plot aesthetic features, such as gridlines and fonts. The following options are provided:
@@ -15,6 +19,8 @@
     - `"print"`: a greyscale-first theme optimised for black-and-white output, with stronger structural elements for improved readability when printed.
     
     - Any `ggplot2::theme()` object, which will be used to modify the `"default"` theme.
+
+- `importUKAQ()` will now import files in parallel if `mirai::daemons()` are set. This will significantly speed up importing large amounts of data.
 
 - `importMeta()` can now filter by site code, site name, site type, pollutants measured, and the distance from a given coordinate.
 

--- a/R/importEurope.R
+++ b/R/importEurope.R
@@ -42,7 +42,7 @@ importEurope <- function(
   # warn/error w/ deprecation
   msg <-
     c(
-      "!" = "{.fun importEurope} has been discontinued and cannot import data after February 2024.",
+      "!" = "{.fun openair::importEurope} has been discontinued and cannot import data after February 2024.",
       "i" = "Consider using the EEA Air Quality Download Service instead {.url https://eeadmz1-downloads-webapp.azurewebsites.net/}"
     )
   if (any(year > 2024)) {

--- a/R/importImperial.R
+++ b/R/importImperial.R
@@ -420,7 +420,7 @@ importKCL <-
   ) {
     cli::cli_warn(
       c(
-        "i" = "{.fun importKCL} has been superseded by, and is equivalent to, {.fun importImperial}. {.strong Please use {.fun importImperial} going forward.}"
+        "i" = "{.fun openair::importKCL} has been superseded by, and is equivalent to, {.fun openair::importImperial}. \\{.strong Please use {.fun openair::importImperial} going forward.}"
       ),
       .frequency = "regularly",
       .frequency_id = "imperial"

--- a/R/importMeta.R
+++ b/R/importMeta.R
@@ -641,7 +641,7 @@ read_imperial_meta <- function(url, all, year) {
 read_saqgetr_meta <- function(url, year) {
   msg <-
     c(
-      "!" = "{.fun importEurope} has been discontinued and cannot import \\
+      "!" = "{.fun openair::importEurope} has been discontinued and cannot import \\
       data after February 2024.",
       "i" = "Consider using the EEA Air Quality Download Service \\
       instead {.url https://eeadmz1-downloads-webapp.azurewebsites.net/}"

--- a/R/importUKAQ-utils.R
+++ b/R/importUKAQ-utils.R
@@ -35,15 +35,23 @@ readUKAQData <-
 
     # suppress warnings for now - unequal factors, harmless
     if (is.null(thedata)) {
-      cli::cli_abort(
-        "No data to import for {.arg site} {.field {site}} and {.arg year} {.field {year}} from {.arg source} {.field {source}}."
-      )
+      if (verbose) {
+        cli::cli_warn(
+          "No data to import for {.arg site} {.field {site}} and {.arg year} {.field {year}} from {.arg source} {.field {source}}."
+        )
+      }
+      return(NULL)
     }
 
     # Return if no data
     if (nrow(thedata) == 0) {
-      return()
-    } ## no data
+      if (verbose) {
+        cli::cli_warn(
+          "No data to import for {.arg site} {.field {site}} and {.arg year} {.field {year}} from {.arg source} {.field {source}}."
+        )
+      }
+      return(NULL)
+    }
 
     # change names
     names(thedata) <- tolower(names(thedata))
@@ -529,7 +537,7 @@ guess_source <- function(site) {
 
     cli::cli_abort(
       c(
-        "x" = "Unknown site codes detected. Please ensure all site codes can be found in {.fun importMeta}.",
+        "x" = "Unknown site codes detected. Please ensure all site codes can be found in {.fun openair::importMeta}.",
         "i" = "Unknown site codes: {ambiguous_codes}"
       )
     )
@@ -564,7 +572,7 @@ guess_source <- function(site) {
           .data$site,
           "' from the source: '",
           .data$source,
-          "'.)"
+          "')"
         )
       ) |>
       dplyr::pull(.data$str)

--- a/R/importUKAQ.R
+++ b/R/importUKAQ.R
@@ -85,15 +85,46 @@
 #'   No corrections have been made to the PM2.5 data. The volatile component of
 #'   FDMS PM2.5 (where available) is shown in the 'v2.5' column.
 #'
+#' @section Parallel Processing:
+#'
+#'   If you are importing a lot of data, this can take a long while. This is
+#'   because each combination of year and site (or just year for annual,
+#'   monthly, or DAQI data) requires downloading a separate data file from WSP's
+#'   online data directory, and the time each download takes can quickly add up.
+#'   The `importUKAQ()` function can use parallel processing to speed
+#'   downloading up, powered by the capable `{mirai}` package.
+#'
+#'   If users have any `{mirai}` "daemons" set, `importUKAQ()` will download
+#'   files in parallel. The greatest benefits will be seen if you spawn as many
+#'   daemons as you have cores on your machine, although one fewer than the
+#'   available cores is often a good rule of thumb. Your mileage may vary,
+#'   however, and naturally spawning more daemons than station-year combinations
+#'   will lead to diminishing returns.
+#'
+#'   ```
+#'   # set workers - once per session
+#'   mirai::daemons(4)
+#'
+#'   # import lots of data - NB: no change in the import function!
+#'   london_aq <- importUKAQ(site = "my1", year = 1980:2025)
+#'   ```
+#'
+#'   As the air quality data files are written as RData and RDS file types,
+#'   reading them into R is already very quick. Users are therefore likely to
+#'   see the most benefit when importing large amounts of data, e.g., entire
+#'   networks of hourly data, or many years of individual sites.
+#'
 #' @param site Site code of the site to import, e.g., `"my1"` is Marylebone
 #'   Road. Site codes can be discovered through the use of [importMeta()].
 #'   Several sites can be imported at once. For example, `site = c("my1",
 #'   "nott")` imports both Marylebone Road and Nottingham. Sites from different
 #'   networks can be imported through also providing multiple `source`s. Site
 #'   codes can be upper or lower case.
+#'
 #' @param year Year(s) to import. To import a series of years use, e.g.,
 #'   `2000:2020`. To import several specific years use `year = c(2000, 2010,
 #'   2020)`.
+#'
 #' @param source The network to which the `site`(s) belong. The default, `NULL`,
 #'   allows [importUKAQ()] to guess the correct `source`, preferring national
 #'   networks over locally managed networks. Alternatively, users can define a
@@ -107,6 +138,7 @@
 #'   - `"waqn"`,  The Welsh Air Quality Network.
 #'   - `"ni"`,  The Northern Ireland Air Quality Network.
 #'   - `"local"`,  Locally managed air quality networks in England.
+#'
 #' @param data_type The type of data to be returned, defaulting to `"hourly"`
 #'   data. Alternative data types include:
 #'   - `"daily"`: Daily average data.
@@ -120,35 +152,44 @@
 #'   [here](https://www.gov.uk/government/publications/health-effects-of-air-pollution)
 #'   for more details of how the index is defined. Note that this `data_type` is
 #'   not available for locally managed monitoring networks.
+#'
 #' @param pollutant Pollutants to import. If omitted will import all pollutants
 #'   from a site. To import only NOx and NO2 for example use `pollutant =
 #'   c("nox", "no2")`. Pollutant names can be upper or lower case.
+#'
 #' @param hc Include hydrocarbon measurements in the imported data? Defaults to
 #'   `FALSE` as most users will not be interested in using hydrocarbon data.
+#'
 #' @param meta Append metadata columns to data for each selected `site`?
 #'   Defaults to `FALSE`. Columns are defined using `meta_columns`.
+#'
 #' @param meta_columns The specific columns to append when `meta = TRUE`.
 #'   Defaults to site type, latitude and longitude. Can be any of `"site_type"`,
 #'   `"latitude"`, `"longitude"`, `"zone"`, `"agglomeration"`, and
 #'   `"local_authority"` (as well as `"provider"` for locally managed data). See
 #'   [importMeta()] for more complete information.
+#'
 #' @param meteo Append modelled meteorological data, if available? Defaults to
 #'   `TRUE`, which will return wind speed (`ws`), wind direction (`wd`) and
 #'   ambient temperature (`air_temp`). The variables are calculated from using
 #'   the WRF model run by WSP and are available for most but not all networks.
 #'   Setting `meteo = FALSE` is useful if you have other meteorological data to
 #'   use in preference, for example from the `worldmet` package.
+#'
 #' @param ratified Append `qc` column(s) to hourly data indicating whether each
 #'   species was ratified (i.e., quality-checked)?  Defaults to `FALSE`.
+#'
 #' @param to_narrow Return the data in a "narrow"/"long"/"tidy" format? By
 #'   default the returned data is "wide" and has a column for each
 #'   pollutant/variable. When `to_narrow = TRUE` the data are returned with a
 #'   column identifying the pollutant name and a column containing the
 #'   corresponding concentration/statistic. Defaults to `FALSE`.
+#'
 #' @param verbose Print messages to the console if hourly data cannot be
 #'   imported? Default is `FALSE`. `TRUE` is useful for debugging as the
 #'   specific `year`(s), `site`(s) and `source`(s) which cannot be imported will
 #'   be returned.
+#'
 #' @param progress Show a progress bar when many sites/years are being imported?
 #'   Defaults to `TRUE`.
 #'
@@ -311,15 +352,45 @@ importUKAQ <-
       files <- unique(files)
 
       # import statistics
-      aq_data <- purrr::pmap(
-        tidyr::crossing(tidyr::nesting(files, source), year),
-        readSummaryData,
-        data_type = data_type,
-        to_narrow = to_narrow,
-        hc = hc,
-        .progress = ifelse(progress, "Importing Statistics", FALSE)
-      ) |>
-        purrr::list_rbind()
+      if (rlang::is_installed("mirai")) {
+        aq_data <- purrr::pmap(
+          tidyr::crossing(tidyr::nesting(files, source), year),
+          purrr::in_parallel(
+            \(files, source, year) {
+              readSummaryData(
+                files = files,
+                year = year,
+                source = source,
+                data_type = data_type,
+                to_narrow = to_narrow,
+                hc = hc
+              )
+            },
+            data_type = data_type,
+            to_narrow = to_narrow,
+            hc = hc,
+            readSummaryData = readSummaryData
+          ),
+          .progress = ifelse(progress, "Importing Statistics", FALSE)
+        ) |>
+          purrr::list_rbind()
+      } else {
+        aq_data <- purrr::pmap(
+          tidyr::crossing(tidyr::nesting(files, source), year),
+          \(files, source, year) {
+            readSummaryData(
+              files = files,
+              year = year,
+              source = source,
+              data_type = data_type,
+              to_narrow = to_narrow,
+              hc = hc
+            )
+          },
+          .progress = ifelse(progress, "Importing Statistics", FALSE)
+        ) |>
+          purrr::list_rbind()
+      }
 
       if (nrow(aq_data) == 0) {
         cli::cli_abort(
@@ -346,13 +417,30 @@ importUKAQ <-
       files <- unique(files)
 
       # import DAQI
-      aq_data <-
-        purrr::pmap(
-          tidyr::crossing(tidyr::nesting(files, source), year),
-          readDAQI,
-          .progress = ifelse(progress, "Importing DAQI", FALSE)
-        ) |>
-        purrr::list_rbind()
+      if (rlang::is_installed("mirai")) {
+        aq_data <-
+          purrr::pmap(
+            tidyr::crossing(tidyr::nesting(files, source), year),
+            purrr::in_parallel(
+              \(files, source, year) {
+                readDAQI(files = files, year = year, source = source)
+              },
+              readDAQI = readDAQI
+            ),
+            .progress = ifelse(progress, "Importing DAQI", FALSE)
+          ) |>
+          purrr::list_rbind()
+      } else {
+        aq_data <-
+          purrr::pmap(
+            tidyr::crossing(tidyr::nesting(files, source), year),
+            \(files, source, year) {
+              readDAQI(files = files, year = year, source = source)
+            },
+            .progress = ifelse(progress, "Importing DAQI", FALSE)
+          ) |>
+          purrr::list_rbind()
+      }
 
       if (nrow(aq_data) == 0) {
         cli::cli_abort(
@@ -415,27 +503,58 @@ importUKAQ <-
           tidyr::crossing(year = year)
       }
 
-      aq_data <-
-        purrr::pmap(
-          .l = site_info,
-          .f = purrr::possibly(
-            ~ readUKAQData(
-              site = ..1,
-              lmam_subfolder = ..4,
-              year = ..5,
-              data_type,
+      if (rlang::is_installed("mirai")) {
+        aq_data <-
+          purrr::pmap(
+            .l = site_info,
+            .f = purrr::in_parallel(
+              \(code, source, url_data, pcode, year) {
+                readUKAQData(
+                  site = code,
+                  lmam_subfolder = pcode,
+                  year = year,
+                  data_type = data_type,
+                  pollutant = pollutant,
+                  hc = hc,
+                  to_narrow = to_narrow,
+                  source = source,
+                  url_data = url_data,
+                  verbose = verbose
+                )
+              },
+              readUKAQData = readUKAQData,
+              to_narrow = to_narrow,
+              data_type = data_type,
               pollutant = pollutant,
               hc = hc,
               to_narrow = to_narrow,
-              source = ..2,
-              url_data = ..3,
               verbose = verbose
             ),
-            quiet = !verbose
-          ),
-          .progress = ifelse(progress, "Importing AQ Data", FALSE)
-        ) |>
-        purrr::list_rbind()
+            .progress = ifelse(progress, "Importing AQ Data", FALSE)
+          ) |>
+          purrr::list_rbind()
+      } else {
+        aq_data <-
+          purrr::pmap(
+            .l = site_info,
+            .f = \(code, source, url_data, pcode, year) {
+              readUKAQData(
+                site = code,
+                lmam_subfolder = pcode,
+                year = year,
+                data_type = data_type,
+                pollutant = pollutant,
+                hc = hc,
+                to_narrow = to_narrow,
+                source = source,
+                url_data = url_data,
+                verbose = verbose
+              )
+            },
+            .progress = ifelse(progress, "Importing AQ Data", FALSE)
+          ) |>
+          purrr::list_rbind()
+      }
 
       if (nrow(aq_data) == 0) {
         cli::cli_abort(

--- a/R/openColours.R
+++ b/R/openColours.R
@@ -275,8 +275,8 @@ openColours <- function(
     if (length(scheme) > 1L && any(scheme %in% .all_schemes)) {
       cli::cli_abort(
         c(
-          "x" = "Please provide {.strong either} 1 {.fun openColours} palette {.emph or} a vector of valid R colours.",
-          "i" = "See {.code ?openColours} for a list of palettes."
+          "x" = "Please provide {.strong either} 1 {.fun openair::openColours} palette {.emph or} a vector of valid R colours.",
+          "i" = "See {.fun openair::openSchemes} for a list of palettes."
         ),
         call = NULL
       )
@@ -285,7 +285,7 @@ openColours <- function(
     if (!all(check)) {
       cli::cli_abort(
         c(
-          "x" = "The following are {.emph neither} valid R colours {.emph nor} {.fun openColours} palettes: {.field {names(check[!check])}}"
+          "x" = "The following are {.emph neither} valid R colours {.emph nor} {.fun openair::openColours} palettes: {.field {names(check[!check])}}"
         ),
         call = NULL
       )

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -160,9 +160,19 @@ check_duplicate_rows <- function(mydata, type = NULL, fn = cli::cli_warn) {
 #'
 #' @param fun The function to apply; should be a function of a dataframe.
 #'
+#' @param ... Other objects passed to [purrr::in_parallel()] for
+#'   `.allow_parallel`.
+#'
 #' @param .include_default If `default` is the only `type`, should any of the
 #'   splitting actually happen? If `FALSE`, no `default` column will be
 #'   returned.
+#'
+#' @param .allow_parallel If `TRUE`, `mirai` can be used to run the map in
+#'   parallel.
+#'
+#' @param .row_bind Bind rows? Sometimes you might not want to do this - e.g.,
+#'   to return a list of different objects. Defaults to `TRUE` as that's by and
+#'   large the most common situation in `openair`.
 #'
 #' @param .progress Show a progress bar?
 #'
@@ -175,7 +185,9 @@ map_type <- function(
   mydata,
   type,
   fun,
+  ...,
   .include_default = FALSE,
+  .allow_parallel = FALSE,
   .row_bind = TRUE,
   .progress = FALSE
 ) {
@@ -183,16 +195,34 @@ map_type <- function(
     return(fun(mydata))
   }
 
-  out <-
-    purrr::map(
-      .x = split(mydata, mydata[type], drop = TRUE),
-      .f = function(df) {
-        out <- fun(df)
-        out[type] <- df[1, type, drop = TRUE]
-        return(out)
-      },
-      .progress = .progress
-    )
+  if (.allow_parallel && rlang::is_installed("mirai")) {
+    out <-
+      purrr::map(
+        .x = split(mydata, mydata[type], drop = TRUE),
+        .f = purrr::in_parallel(
+          function(df) {
+            out <- fun(df)
+            out[type] <- df[1, type, drop = TRUE]
+            return(out)
+          },
+          fun = fun,
+          type = type,
+          ...
+        ),
+        .progress = .progress
+      )
+  } else {
+    out <-
+      purrr::map(
+        .x = split(mydata, mydata[type], drop = TRUE),
+        .f = function(df) {
+          out <- fun(df)
+          out[type] <- df[1, type, drop = TRUE]
+          return(out)
+        },
+        .progress = .progress
+      )
+  }
 
   if (.row_bind) {
     out <-

--- a/man/importUKAQ.Rd
+++ b/man/importUKAQ.Rd
@@ -189,6 +189,36 @@ No corrections have been made to the PM2.5 data. The volatile component of
 FDMS PM2.5 (where available) is shown in the 'v2.5' column.
 }
 
+\section{Parallel Processing}{
+
+
+If you are importing a lot of data, this can take a long while. This is
+because each combination of year and site (or just year for annual,
+monthly, or DAQI data) requires downloading a separate data file from WSP's
+online data directory, and the time each download takes can quickly add up.
+The \code{importUKAQ()} function can use parallel processing to speed
+downloading up, powered by the capable \code{{mirai}} package.
+
+If users have any \code{{mirai}} "daemons" set, \code{importUKAQ()} will download
+files in parallel. The greatest benefits will be seen if you spawn as many
+daemons as you have cores on your machine, although one fewer than the
+available cores is often a good rule of thumb. Your mileage may vary,
+however, and naturally spawning more daemons than station-year combinations
+will lead to diminishing returns.
+
+\if{html}{\out{<div class="sourceCode">}}\preformatted{# set workers - once per session
+mirai::daemons(4)
+
+# import lots of data - NB: no change in the import function!
+london_aq <- importUKAQ(site = "my1", year = 1980:2025)
+}\if{html}{\out{</div>}}
+
+As the air quality data files are written as RData and RDS file types,
+reading them into R is already very quick. Users are therefore likely to
+see the most benefit when importing large amounts of data, e.g., entire
+networks of hourly data, or many years of individual sites.
+}
+
 \examples{
 \dontrun{
 # import a single site from the AURN


### PR DESCRIPTION
This PR adds parallel processing to `importUKAQ()`, and also adds mirai/carrier as suggested packages.

There are diminishing returns at low numbers of sites, but at large numbers of sites its really significant.

For example, doing this:

```r
meta <- importMeta(year = 2020:2025)
importUKAQ(site = meta$code, year = 2020:2025)
```

It really does reduce the amount of time it takes to import this large amount of data:

<img width="661" height="461" alt="image" src="https://github.com/user-attachments/assets/8a3b3a24-6d78-46fb-9d07-eba54ab371ec" />