### PR TITLE
feat: add `label` to `refOpts()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,7 @@ Suggests:
     geomtextpath,
     KernSmooth,
     knitr,
-    legendry (>= 0.2.4),
+    legendry (>= 0.3.0),
     quantreg,
     rmarkdown,
     rnaturalearth,
@@ -57,10 +57,10 @@ LinkingTo:
     Rcpp
 ByteCompile: true
 Config/Needs/website: openair-project/openairpkgdown
+Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
 Encoding: UTF-8
 Language: en-GB
 LazyData: yes
 LazyLoad: yes
 Roxygen: list(markdown = TRUE)
-Config/roxygen2/version: 8.0.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,8 @@
 
 - Added `distPlot()`, which flexibly plots histograms and density functions to examine the 'shape' of the distribution of numeric data.
 
+- `refOpts()` gains the `label`, `label_size` and `label_colo(u)r` arguments. These options require the `{legendry}` package and add direct labels to the reference lines on the opposite side to the numeric axes.
+
 - `timePlot()` gains the `step` argument which causes a "stairstep" plot to be created instead of a traditional line chart. This is likely most useful for low resolution or 'multi-day' (e.g., diffusion tube) data.
 
 ## Bug Fixes

--- a/R/refOpts.R
+++ b/R/refOpts.R
@@ -24,6 +24,12 @@
 #' @param linewidth Numeric value specifying the width of the lines. Default is
 #'   1.
 #'
+#' @param label,label_size,label_colour,label_color `label` takes character
+#'   string to add a direct label to the reference line. For `ref.x` this will
+#'   be on the right hand side of the plot, and for `ref.y` this will be on top.
+#'   `label_size` and `label_colour` set label aesethetics, with the latter
+#'   defaulting to `colour` if not set.
+#'
 #' @return A list of options that can be passed to the `ref.x` or `ref.y`
 #'   arguments of functions like [timePlot()].
 #'
@@ -50,8 +56,12 @@ refOpts <- function(
   alpha = 1,
   colour = "black",
   linetype = 1,
-  linewidth = 1,
-  color = NULL
+  linewidth = 0.6,
+  label = NULL,
+  label_size = 10,
+  label_colour = NULL,
+  color = NULL,
+  label_color = NULL
 ) {
   if (missing(colour) && !is.null(color)) {
     colour <- color
@@ -61,7 +71,10 @@ refOpts <- function(
     alpha = alpha,
     colour = colour,
     linetype = linetype,
-    linewidth = linewidth
+    linewidth = linewidth,
+    label = label,
+    label_size = label_size,
+    label_colour = label_colour %||% label_color %||% colour
   )
 }
 
@@ -125,25 +138,46 @@ layer_ref <- function(
   # recycle aesthetics if needed
   alpha <- recycle_to_length(ref$alpha %||% 1, n)
   colour <- recycle_to_length(ref$colour %||% ref$col %||% "black", n)
-  linetype <- recycle_to_length(ref$linetype %||% ref$lty %||% 1, n)
+  linetype <- recycle_to_length(ref$linetype %||% ref$lty %||% 0.6, n)
   linewidth <- recycle_to_length(ref$linewidth %||% ref$lwd %||% 0.5, n)
+  label_size <- recycle_to_length(ref$label_size %||% 10, n)
+  label_colour <- recycle_to_length(ref$label_colour %||% 10, n)
+
+  label <- ref$label
+  use_label <- any(!is.null(label))
+  if (use_label) {
+    if (length(label) != n) {
+      cli::cli_abort("One {.arg label} needed per {.arg intercept}.")
+    }
+    rlang::check_installed(
+      "legendry",
+      reason = "to add labels to reference lines.",
+      version = "0.3.0"
+    )
+  }
 
   # choose appropriate function
   if (which == "x") {
-    fun <- \(intercept, ...) {
+    geom_fun <- \(intercept, ...) {
       ggplot2::geom_vline(xintercept = intercept, ..., inherit.aes = FALSE)
     }
+    annotate_fun <- \(intercept, label, ...) {
+      legendry::annotate_top(aesthetic = intercept, label = label, ...)
+    }
   } else if (which == "y") {
-    fun <- \(intercept, ...) {
+    geom_fun <- \(intercept, ...) {
       ggplot2::geom_hline(yintercept = intercept, ..., inherit.aes = FALSE)
+    }
+    annotate_fun <- \(intercept, label, ...) {
+      legendry::annotate_right(aesthetic = intercept, label = label, ...)
     }
   }
 
   # Build list of geoms
-  purrr::pmap(
+  geoms <- purrr::pmap(
     .l = list(intercept, alpha, colour, linetype, linewidth),
     .f = function(intercept, alpha, colour, linetype, linewidth) {
-      fun(
+      geom_fun(
         intercept = intercept,
         alpha = alpha,
         colour = colour,
@@ -152,4 +186,20 @@ layer_ref <- function(
       )
     }
   )
+
+  if (use_label) {
+    return(append(
+      geoms,
+      annotate_fun(
+        intercept = intercept,
+        label = label,
+        size = label_size,
+        colour = label_colour,
+        linetype = linetype,
+        linewidth = linewidth
+      )
+    ))
+  } else {
+    return(geoms)
+  }
 }

--- a/man/refOpts.Rd
+++ b/man/refOpts.Rd
@@ -9,8 +9,12 @@ refOpts(
   alpha = 1,
   colour = "black",
   linetype = 1,
-  linewidth = 1,
-  color = NULL
+  linewidth = 0.6,
+  label = NULL,
+  label_size = 10,
+  label_colour = NULL,
+  color = NULL,
+  label_color = NULL
 )
 }
 \arguments{
@@ -32,6 +36,12 @@ dashed) or a string (e.g., "solid", "dashed"). Default is 1 (solid).}
 
 \item{linewidth}{Numeric value specifying the width of the lines. Default is
 1.}
+
+\item{label, label_size, label_colour, label_color}{\code{label} takes character
+string to add a direct label to the reference line. For \code{ref.x} this will
+be on the right hand side of the plot, and for \code{ref.y} this will be on top.
+\code{label_size} and \code{label_colour} set label aesethetics, with the latter
+defaulting to \code{colour} if not set.}
 }
 \value{
 A list of options that can be passed to the \code{ref.x} or \code{ref.y}


### PR DESCRIPTION
This PR adds the `label` and other arguments to `refOpts()`. It allows for direct labelling of reference lines.

```r
daqi <- openair::importUKAQ(
  year = 2025, 
  source = "aurn", 
  data_type = "daqi", 
  pollutant = "o3"
)

daqi |> 
  dplyr::summarise(
    concentration = max(concentration, na.rm = T), 
    .by = date
  ) |>
  timePlot(
    cols = "black",
    "concentration",
    ref.y = refOpts(
      c(0, 101, 161, 241),
      color = c("#009900FF", "#ff9900FF", "#ff0000FF", "#990099FF"),
      label = c("Low", "Moderate", "High", "Very High")
    )
  )
```

<img width="1071" height="458" alt="image" src="https://github.com/user-attachments/assets/1d571dc5-5135-49ec-bfbe-5baa99a2a54f" />
